### PR TITLE
Register hook

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,9 @@ jobs:
       - name: Install dependencies
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Check
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--no-multiarch"), error_on = "error", check_dir = "check")
+        run:  |
+          print(Sys.info())
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--no-multiarch"), error_on = "error", check_dir = "check")
         shell: Rscript {0}
       - name: Reveal testthat details
         run: find . -name testthat.Rout -exec cat '{}' ';'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,7 @@ jobs:
             cran: https://demo.rstudiopm.com/all/__linux__/bionic/latest
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
+    timeout-minutes: 20
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       INSTALL_TORCH: 1

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,10 @@ cpp_tensor_requires_grad <- function(self) {
     .Call('_torchr_cpp_tensor_requires_grad', PACKAGE = 'torchr', self)
 }
 
+cpp_tensor_register_hook <- function(self) {
+    invisible(.Call('_torchr_cpp_tensor_register_hook', PACKAGE = 'torchr', self))
+}
+
 cpp_device_type_to_string <- function(device) {
     .Call('_torchr_cpp_device_type_to_string', PACKAGE = 'torchr', device)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,10 @@ cpp_tensor_requires_grad <- function(self) {
     .Call('_torchr_cpp_tensor_requires_grad', PACKAGE = 'torchr', self)
 }
 
+cpp_torch_method_backward_self_Tensor <- function(self, gradient, keep_graph, create_graph) {
+    invisible(.Call('_torchr_cpp_torch_method_backward_self_Tensor', PACKAGE = 'torchr', self, gradient, keep_graph, create_graph))
+}
+
 cpp_tensor_register_hook <- function(self, f) {
     invisible(.Call('_torchr_cpp_tensor_register_hook', PACKAGE = 'torchr', self, f))
 }
@@ -95,10 +99,6 @@ cpp_torch_qint8 <- function() {
 
 cpp_torch_qint32 <- function() {
     .Call('_torchr_cpp_torch_qint32', PACKAGE = 'torchr')
-}
-
-cpp_torch_method_backward_self_Tensor <- function(self, gradient, keep_graph, create_graph) {
-    invisible(.Call('_torchr_cpp_torch_method_backward_self_Tensor', PACKAGE = 'torchr', self, gradient, keep_graph, create_graph))
 }
 
 cpp_torch_method_set_data_self_Tensor_new_data_Tensor <- function(self, new_data) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,8 +13,8 @@ cpp_tensor_requires_grad <- function(self) {
     .Call('_torchr_cpp_tensor_requires_grad', PACKAGE = 'torchr', self)
 }
 
-cpp_tensor_register_hook <- function(self) {
-    invisible(.Call('_torchr_cpp_tensor_register_hook', PACKAGE = 'torchr', self))
+cpp_tensor_register_hook <- function(self, f) {
+    invisible(.Call('_torchr_cpp_tensor_register_hook', PACKAGE = 'torchr', self, f))
 }
 
 cpp_device_type_to_string <- function(device) {

--- a/R/autograd.R
+++ b/R/autograd.R
@@ -75,7 +75,11 @@ Tensor$set("public", "backward", function(gradient = list(), keep_graph = FALSE,
 
 Tensor$set("public", "register_hook", function(hook) {
   aux <- function(grad) {
-    hook(Tensor$new(ptr = grad))
+    out <- hook(Tensor$new(ptr = grad))
+    if (!is_torch_tensor(out))
+      cpp_tensor_undefined()
+    else
+      out$ptr
   }
   cpp_tensor_register_hook(self$ptr, aux)
 })

--- a/R/autograd.R
+++ b/R/autograd.R
@@ -75,7 +75,6 @@ Tensor$set("public", "backward", function(gradient = list(), keep_graph = FALSE,
 
 Tensor$set("public", "register_hook", function(hook) {
   aux <- function(grad) {
-    print("yes")
     hook(Tensor$new(ptr = grad))
   }
   cpp_tensor_register_hook(self$ptr, aux)

--- a/R/autograd.R
+++ b/R/autograd.R
@@ -73,6 +73,15 @@ Tensor$set("public", "backward", function(gradient = list(), keep_graph = FALSE,
   invisible(private$`_backward`(gradient, keep_graph, create_graph))
 })
 
+Tensor$set("public", "register_hook", function(hook) {
+  aux <- function(grad) {
+    print("yes")
+    hook(Tensor$new(ptr = grad))
+  }
+  cpp_tensor_register_hook(self$ptr, aux)
+})
+
+
 #' Set grad mode
 #' 
 #' Sets or disables gradient history.

--- a/R/lantern_install.R
+++ b/R/lantern_install.R
@@ -1,4 +1,4 @@
-branch <- "register_hook"
+branch <- "master"
 
 install_config <- list(
   "1.4.0" = list(

--- a/R/lantern_install.R
+++ b/R/lantern_install.R
@@ -1,4 +1,4 @@
-branch <- "master"
+branch <- "register_hook"
 
 install_config <- list(
   "1.4.0" = list(

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -39,12 +39,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_tensor_register_hook
-void cpp_tensor_register_hook(Rcpp::XPtr<XPtrTorchTensor> self);
-RcppExport SEXP _torchr_cpp_tensor_register_hook(SEXP selfSEXP) {
+void cpp_tensor_register_hook(Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f);
+RcppExport SEXP _torchr_cpp_tensor_register_hook(SEXP selfSEXP, SEXP fSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type self(selfSEXP);
-    cpp_tensor_register_hook(self);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type f(fSEXP);
+    cpp_tensor_register_hook(self, f);
     return R_NilValue;
 END_RCPP
 }
@@ -22254,7 +22255,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torchr_cpp_autograd_set_grad_mode", (DL_FUNC) &_torchr_cpp_autograd_set_grad_mode, 1},
     {"_torchr_cpp_tensor_grad", (DL_FUNC) &_torchr_cpp_tensor_grad, 1},
     {"_torchr_cpp_tensor_requires_grad", (DL_FUNC) &_torchr_cpp_tensor_requires_grad, 1},
-    {"_torchr_cpp_tensor_register_hook", (DL_FUNC) &_torchr_cpp_tensor_register_hook, 1},
+    {"_torchr_cpp_tensor_register_hook", (DL_FUNC) &_torchr_cpp_tensor_register_hook, 2},
     {"_torchr_cpp_device_type_to_string", (DL_FUNC) &_torchr_cpp_device_type_to_string, 1},
     {"_torchr_cpp_device_index_to_int", (DL_FUNC) &_torchr_cpp_device_index_to_int, 1},
     {"_torchr_cpp_torch_device", (DL_FUNC) &_torchr_cpp_torch_device, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -38,6 +38,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_torch_method_backward_self_Tensor
+void cpp_torch_method_backward_self_Tensor(Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::XPtr<XPtrTorchTensor> gradient, bool keep_graph, bool create_graph);
+RcppExport SEXP _torchr_cpp_torch_method_backward_self_Tensor(SEXP selfSEXP, SEXP gradientSEXP, SEXP keep_graphSEXP, SEXP create_graphSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type self(selfSEXP);
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type gradient(gradientSEXP);
+    Rcpp::traits::input_parameter< bool >::type keep_graph(keep_graphSEXP);
+    Rcpp::traits::input_parameter< bool >::type create_graph(create_graphSEXP);
+    cpp_torch_method_backward_self_Tensor(self, gradient, keep_graph, create_graph);
+    return R_NilValue;
+END_RCPP
+}
 // cpp_tensor_register_hook
 void cpp_tensor_register_hook(Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f);
 RcppExport SEXP _torchr_cpp_tensor_register_hook(SEXP selfSEXP, SEXP fSEXP) {
@@ -256,19 +269,6 @@ BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     rcpp_result_gen = Rcpp::wrap(cpp_torch_qint32());
     return rcpp_result_gen;
-END_RCPP
-}
-// cpp_torch_method_backward_self_Tensor
-void cpp_torch_method_backward_self_Tensor(Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::XPtr<XPtrTorchTensor> gradient, bool keep_graph, bool create_graph);
-RcppExport SEXP _torchr_cpp_torch_method_backward_self_Tensor(SEXP selfSEXP, SEXP gradientSEXP, SEXP keep_graphSEXP, SEXP create_graphSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type self(selfSEXP);
-    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type gradient(gradientSEXP);
-    Rcpp::traits::input_parameter< bool >::type keep_graph(keep_graphSEXP);
-    Rcpp::traits::input_parameter< bool >::type create_graph(create_graphSEXP);
-    cpp_torch_method_backward_self_Tensor(self, gradient, keep_graph, create_graph);
-    return R_NilValue;
 END_RCPP
 }
 // cpp_torch_method_set_data_self_Tensor_new_data_Tensor
@@ -22255,6 +22255,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torchr_cpp_autograd_set_grad_mode", (DL_FUNC) &_torchr_cpp_autograd_set_grad_mode, 1},
     {"_torchr_cpp_tensor_grad", (DL_FUNC) &_torchr_cpp_tensor_grad, 1},
     {"_torchr_cpp_tensor_requires_grad", (DL_FUNC) &_torchr_cpp_tensor_requires_grad, 1},
+    {"_torchr_cpp_torch_method_backward_self_Tensor", (DL_FUNC) &_torchr_cpp_torch_method_backward_self_Tensor, 4},
     {"_torchr_cpp_tensor_register_hook", (DL_FUNC) &_torchr_cpp_tensor_register_hook, 2},
     {"_torchr_cpp_device_type_to_string", (DL_FUNC) &_torchr_cpp_device_type_to_string, 1},
     {"_torchr_cpp_device_index_to_int", (DL_FUNC) &_torchr_cpp_device_index_to_int, 1},
@@ -22276,7 +22277,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torchr_cpp_torch_quint8", (DL_FUNC) &_torchr_cpp_torch_quint8, 0},
     {"_torchr_cpp_torch_qint8", (DL_FUNC) &_torchr_cpp_torch_qint8, 0},
     {"_torchr_cpp_torch_qint32", (DL_FUNC) &_torchr_cpp_torch_qint32, 0},
-    {"_torchr_cpp_torch_method_backward_self_Tensor", (DL_FUNC) &_torchr_cpp_torch_method_backward_self_Tensor, 4},
     {"_torchr_cpp_torch_method_set_data_self_Tensor_new_data_Tensor", (DL_FUNC) &_torchr_cpp_torch_method_set_data_self_Tensor_new_data_Tensor, 2},
     {"_torchr_cpp_torch_method_data_self_Tensor", (DL_FUNC) &_torchr_cpp_torch_method_data_self_Tensor, 1},
     {"_torchr_cpp_torch_method_is_leaf_self_Tensor", (DL_FUNC) &_torchr_cpp_torch_method_is_leaf_self_Tensor, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -38,6 +38,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_tensor_register_hook
+void cpp_tensor_register_hook(Rcpp::XPtr<XPtrTorchTensor> self);
+RcppExport SEXP _torchr_cpp_tensor_register_hook(SEXP selfSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type self(selfSEXP);
+    cpp_tensor_register_hook(self);
+    return R_NilValue;
+END_RCPP
+}
 // cpp_device_type_to_string
 std::string cpp_device_type_to_string(Rcpp::XPtr<XPtrTorchDevice> device);
 RcppExport SEXP _torchr_cpp_device_type_to_string(SEXP deviceSEXP) {
@@ -22244,6 +22254,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torchr_cpp_autograd_set_grad_mode", (DL_FUNC) &_torchr_cpp_autograd_set_grad_mode, 1},
     {"_torchr_cpp_tensor_grad", (DL_FUNC) &_torchr_cpp_tensor_grad, 1},
     {"_torchr_cpp_tensor_requires_grad", (DL_FUNC) &_torchr_cpp_tensor_requires_grad, 1},
+    {"_torchr_cpp_tensor_register_hook", (DL_FUNC) &_torchr_cpp_tensor_register_hook, 1},
     {"_torchr_cpp_device_type_to_string", (DL_FUNC) &_torchr_cpp_device_type_to_string, 1},
     {"_torchr_cpp_device_index_to_int", (DL_FUNC) &_torchr_cpp_device_index_to_int, 1},
     {"_torchr_cpp_torch_device", (DL_FUNC) &_torchr_cpp_torch_device, 2},

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -15,3 +15,12 @@ Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
 bool cpp_tensor_requires_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
   return lantern_Tensor_requires_grad(self->get());
 }
+
+// [[Rcpp::export]]
+void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self) {
+  void *fun = (void *)new std::function<void(void *)>([](void *x) {
+    std::cout << "hello hello" << std::endl;
+  });
+  auto hook = lantern_new_hook(fun);
+  lantern_Tensor_register_hook(self->get(), hook);
+}

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -17,9 +17,12 @@ bool cpp_tensor_requires_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
 }
 
 // [[Rcpp::export]]
-void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self) {
-  void *fun = (void *)new std::function<void(void *)>([](void *x) {
-    std::cout << "hello hello" << std::endl;
+void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f) {
+  void *fun = (void *)new std::function<void(void *)>([f](void *x) {
+    Rcpp::Rcout << "hey" << std::endl;
+    auto y = make_xptr<XPtrTorchTensor>(x);
+    Rcpp::Rcout << "hey2" << std::endl;
+    f(y);
   });
   auto hook = lantern_new_hook(fun);
   lantern_Tensor_register_hook(self->get(), hook);

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -16,14 +16,19 @@ bool cpp_tensor_requires_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
   return lantern_Tensor_requires_grad(self->get());
 }
 
+#include <thread>
+
 // [[Rcpp::export]]
 void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f) {
+  Rcpp::Rcout << std::this_thread::get_id() << std::endl;
   void *fun = (void *)new std::function<void(void *)>([f](void *x) {
+    Rcpp::Rcout << std::this_thread::get_id() << std::endl;
     Rcpp::Rcout << "hey" << std::endl;
     auto y = make_xptr<XPtrTorchTensor>(x);
     Rcpp::Rcout << "hey2" << std::endl;
-    f(y);
   });
   auto hook = lantern_new_hook(fun);
   lantern_Tensor_register_hook(self->get(), hook);
 }
+
+

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -18,16 +18,20 @@ bool cpp_tensor_requires_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
 
 #include <thread>
 
+void rcpp_call_hook (void* x, void* hook) {
+  (*reinterpret_cast<std::function<void(void*)> *>(hook))(x);
+}
+
 // [[Rcpp::export]]
 void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f) {
   Rcpp::Rcout << std::this_thread::get_id() << std::endl;
-  void *fun = (void *)new std::function<void(void *)>([f](void *x) {
+  auto r_hook = (void *)new std::function<void(void *)>([f](void *x) {
     Rcpp::Rcout << std::this_thread::get_id() << std::endl;
     Rcpp::Rcout << "hey" << std::endl;
     auto y = make_xptr<XPtrTorchTensor>(x);
     Rcpp::Rcout << "hey2" << std::endl;
   });
-  auto hook = lantern_new_hook(fun);
+  auto hook = lantern_new_hook(&rcpp_call_hook, r_hook);
   lantern_Tensor_register_hook(self->get(), hook);
 }
 

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -1,5 +1,7 @@
 #include "torchr_types.h"
 #include "utils.hpp"
+#include <deque>
+#include <future>
 
 // [[Rcpp::export]]
 void cpp_autograd_set_grad_mode (bool enabled) {
@@ -18,6 +20,37 @@ bool cpp_tensor_requires_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
 
 #include <thread>
 
+std::deque<std::packaged_task<void()>> tasks;
+std::mutex tasks_mutex;
+std::atomic<bool> event_loop_running;
+
+void event_loop_thread();
+
+// [[Rcpp::export]]
+void cpp_torch_method_backward_self_Tensor (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::XPtr<XPtrTorchTensor> gradient, bool keep_graph, bool create_graph) {
+  
+  auto self_ptr = self->get();
+  auto gradient_ptr = gradient->get();
+  auto keep_graph_val = keep_graph;
+  auto create_graph_val = create_graph;
+  
+  Rcpp::Rcout << "spining new thread" << std::endl;
+  
+  event_loop_running = true;
+  std::thread t([&](){
+    lantern_Tensor_backward_tensor_tensor_bool_bool(self_ptr, gradient_ptr, 
+                                                    reinterpret_cast<void*>(&keep_graph_val), 
+                                                    reinterpret_cast<void*>(&create_graph_val)); 
+    event_loop_running = false;
+  });
+  
+  Rcpp::Rcout << "thread started!" << std::endl;
+  
+  event_loop_thread();
+  
+  t.join();
+}
+
 void rcpp_call_hook (void* x, void* hook) {
   (*reinterpret_cast<std::function<void(void*)> *>(hook))(x);
 }
@@ -25,14 +58,49 @@ void rcpp_call_hook (void* x, void* hook) {
 // [[Rcpp::export]]
 void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f) {
   Rcpp::Rcout << std::this_thread::get_id() << std::endl;
+  
   auto r_hook = (void *)new std::function<void(void *)>([f](void *x) {
-    Rcpp::Rcout << std::this_thread::get_id() << std::endl;
-    Rcpp::Rcout << "hey" << std::endl;
-    auto y = make_xptr<XPtrTorchTensor>(x);
-    Rcpp::Rcout << "hey2" << std::endl;
+    std::packaged_task<void()> task([f, x]() {
+      auto y = make_xptr<XPtrTorchTensor>(x);
+      f(y);
+    });
+    std::future<void> result = task.get_future();
+    
+    {
+      std::lock_guard<std::mutex> lock(tasks_mutex);
+      tasks.push_back(std::move(task));
+    }
+    
+    // wait on result
+    result.get();
   });
   auto hook = lantern_new_hook(&rcpp_call_hook, r_hook);
   lantern_Tensor_register_hook(self->get(), hook);
 }
 
-
+void event_loop_thread()
+{
+  Rcpp::Rcout << "entering the event loop thread!" << std::endl;
+  Rcpp::Rcout << "event pool running: " << event_loop_running << std::endl;
+  
+  while (event_loop_running) {
+    // process messages
+    {
+      std::unique_lock<std::mutex> lock(tasks_mutex);
+      while (!tasks.empty()) {
+        auto task(std::move(tasks.front()));
+        tasks.pop_front();
+        
+        // unlock during the task
+        lock.unlock();
+        std::cout << "running task" << std::endl;
+        task();
+        std::cout << "finished task" << std::endl;
+        lock.lock();
+      }
+    }
+    
+  }
+  
+  Rcpp::Rcout << "leaving event_lopp thread;" << std::endl;
+}

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -2,6 +2,7 @@
 #include "utils.hpp"
 #include <deque>
 #include <future>
+#include <thread>
 
 // [[Rcpp::export]]
 void cpp_autograd_set_grad_mode (bool enabled) {
@@ -18,8 +19,6 @@ bool cpp_tensor_requires_grad (Rcpp::XPtr<XPtrTorchTensor> self) {
   return lantern_Tensor_requires_grad(self->get());
 }
 
-#include <thread>
-
 std::deque<std::packaged_task<void*()>> tasks;
 std::deque<std::packaged_task<void()>> backward_tasks;
 std::atomic<bool> is_nested;
@@ -28,30 +27,23 @@ std::mutex backward_tasks_mutex;
 
 void event_loop_thread(std::atomic<bool> &event_loop_running)
 {
-  Rcpp::Rcout << "entering the event loop thread!" << std::endl;
-  Rcpp::Rcout << "event pool running: " << event_loop_running << std::endl;
   
   while (event_loop_running) {
-    // process messages
+    
     {
       std::unique_lock<std::mutex> lock(tasks_mutex);
-      //std::cout << "number of tasks " << tasks.size() << std::endl;
       while (!tasks.empty()) {
         auto task(std::move(tasks.front()));
         tasks.pop_front();
         
-        // unlock during the task
         lock.unlock();
-        std::cout << "running task" << std::endl;
         task();
-        std::cout << "finished task" << std::endl;
         lock.lock();
       }
     }
     
   }
   
-  Rcpp::Rcout << "leaving event_lopp thread;" << std::endl;
 }
 
 // [[Rcpp::export]]
@@ -66,91 +58,58 @@ void cpp_torch_method_backward_self_Tensor (Rcpp::XPtr<XPtrTorchTensor> self, Rc
   
   event_loop_running = true;
   std::future<void> result;
+  
+  std::function<void()> backward ([&](){
+    
+    try
+    {
+      lantern_Tensor_backward_tensor_tensor_bool_bool(
+        self_ptr, gradient_ptr, 
+        reinterpret_cast<void*>(&keep_graph_val), 
+        reinterpret_cast<void*>(&create_graph_val)
+      );
+    }
+    catch (...)
+    {
+      event_loop_running = false;
+      is_nested = false;
+      throw;
+    }
+    
+    event_loop_running = false;
+    is_nested = false;
+  });
+  
   if (!is_nested)
   {
-    Rcpp::Rcout << "spining new thread" << std::endl;
-    
-    result = std::async([&](){
-      std::cout << "running this fun async" << std::endl;
-      try
-      {
-        lantern_Tensor_backward_tensor_tensor_bool_bool(
-          self_ptr, gradient_ptr, 
-          reinterpret_cast<void*>(&keep_graph_val), 
-          reinterpret_cast<void*>(&create_graph_val)
-        );
-        std::cout << "finished backwarding" << std::endl;
-      }
-      catch (...)
-      {
-        event_loop_running = false;
-        is_nested = false;
-        throw;
-      }
-      
-      event_loop_running = false;
-      is_nested = false;
-    }); 
+    result = std::async(backward); 
     is_nested = true;
+  } 
+  else 
+  {
     
-    Rcpp::Rcout << "thread started!" << std::endl;
-  } else {
-    
-    std::cout << "Creatig new backward task" << std::endl;
-    
-    std::packaged_task<void()> task([&](){
-      std::cout << "running this fun async" << std::endl;
-      try
-      {
-        lantern_Tensor_backward_tensor_tensor_bool_bool(
-          self_ptr, gradient_ptr, 
-          reinterpret_cast<void*>(&keep_graph_val), 
-          reinterpret_cast<void*>(&create_graph_val)
-        );
-        std::cout << "finished backwarding" << std::endl;
-      }
-      catch (...)
-      {
-        event_loop_running = false;
-        is_nested = false;
-        throw;
-      }
-      
-      event_loop_running = false;
-      is_nested = false;
-      
-    });
+    std::packaged_task<void()> task(backward);
     result = task.get_future();
-    
     
     {
       std::lock_guard<std::mutex> lock(tasks_mutex);
-      std::cout << "Pushing new task" << std::endl;
       backward_tasks.push_front(std::move(task));
     }
     
-    std::cout << "Finished publishing task" << std::endl;
-    
   }
+  
   event_loop_thread(event_loop_running);
   result.get();
 }
 
 void*  rcpp_call_hook (void* x, void* hook) {
-  std::cout << "Calling hook" << std::endl;
   return (*reinterpret_cast<std::function<void*(void*)> *>(hook))(x);
 }
 
-#include <fstream>
-#include <iostream>
-
 // [[Rcpp::export]]
 void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function f) {
-  Rcpp::Rcout << std::this_thread::get_id() << std::endl;
   
   auto r_hook = (void *)new std::function<void*(void *)>([f](void *x) {
-    
-    std::cout << "Creating packaged task!" << std::endl;
     
     std::packaged_task<void*()> task([f, x]() {
       auto y = make_xptr<XPtrTorchTensor>(x);
@@ -158,42 +117,33 @@ void cpp_tensor_register_hook (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Function 
     });
     std::future<void*> result = task.get_future();
     
-    std::cout << "OK! Locking tasks to push new task." << std::endl;
-    
     {
       std::lock_guard<std::mutex> lock(tasks_mutex);
-      std::cout << "Pushing new task" << std::endl;
       tasks.push_front(std::move(task));
     }
     
-    std::cout << "Tasked has ben pushed; wait for results" << std::endl;
-    
     std::future_status status;
     do {
-      status = result.wait_for(std::chrono::seconds(1));
+      status = result.wait_for(std::chrono::seconds(0));
       if (status == std::future_status::timeout) {
         
         std::unique_lock<std::mutex> lock(backward_tasks_mutex);
-        //std::cout << "number of tasks " << tasks.size() << std::endl;
         while (!backward_tasks.empty()) {
           auto task(std::move(backward_tasks.front()));
           backward_tasks.pop_front();
           
           // unlock during the task
           lock.unlock();
-          std::cout << "running backward task" << std::endl;
           task();
-          std::cout << "finished backward task" << std::endl;
           lock.lock();
         }
         
-        std::cout << "timeout\n";
       } 
     } while (status != std::future_status::ready); 
     
-    // wait on result
     return result.get();
   });
+  
   auto hook = lantern_new_hook(&rcpp_call_hook, r_hook);
   lantern_Tensor_register_hook(self->get(), hook);
 }

--- a/src/gen-namespace.cpp
+++ b/src/gen-namespace.cpp
@@ -1,8 +1,6 @@
 // This file is auto generated. Dont modify it by hand.
 #include "utils.hpp"
 
-
-
 // [[Rcpp::export]]
 void cpp_torch_method_set_data_self_Tensor_new_data_Tensor (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::XPtr<XPtrTorchTensor> new_data) {
   lantern_Tensor_set_data_tensor_tensor(self->get(), new_data->get());

--- a/src/gen-namespace.cpp
+++ b/src/gen-namespace.cpp
@@ -1,10 +1,7 @@
 // This file is auto generated. Dont modify it by hand.
 #include "utils.hpp"
 
-// [[Rcpp::export]]
-void cpp_torch_method_backward_self_Tensor (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::XPtr<XPtrTorchTensor> gradient, bool keep_graph, bool create_graph) {
-  lantern_Tensor_backward_tensor_tensor_bool_bool(self->get(), gradient->get(), reinterpret_cast<void*>(&keep_graph), reinterpret_cast<void*>(&create_graph));
-}
+
 
 // [[Rcpp::export]]
 void cpp_torch_method_set_data_self_Tensor_new_data_Tensor (Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::XPtr<XPtrTorchTensor> new_data) {

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -133,6 +133,7 @@ extern "C"
   LANTERN_API void(LANTERN_PTR lantern_test_register_hook)();
   LANTERN_API void(LANTERN_PTR lantern_Tensor_register_hook)(void *self, void *hook);
   LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void *(*fun)(void *, void *), void *custom);
+  LANTERN_API void(LANTERN_PTR test_hooks)();
 
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);
@@ -2017,6 +2018,7 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(lantern_test_register_hook);
   LOAD_SYMBOL(lantern_Tensor_register_hook);
   LOAD_SYMBOL(lantern_new_hook);
+  LOAD_SYMBOL(test_hooks);
 
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(lantern__cast_byte_tensor_bool)

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -132,7 +132,7 @@ extern "C"
   LANTERN_API bool(LANTERN_PTR lantern_Tensor_requires_grad)(void *self);
   LANTERN_API void(LANTERN_PTR lantern_test_register_hook)();
   LANTERN_API void(LANTERN_PTR lantern_Tensor_register_hook)(void *self, void *hook);
-  LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void *fun);
+  LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void (*fun)(void *, void *), void *custom);
 
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -132,7 +132,7 @@ extern "C"
   LANTERN_API bool(LANTERN_PTR lantern_Tensor_requires_grad)(void *self);
   LANTERN_API void(LANTERN_PTR lantern_test_register_hook)();
   LANTERN_API void(LANTERN_PTR lantern_Tensor_register_hook)(void *self, void *hook);
-  LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void (*fun)(void *, void *), void *custom);
+  LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void *(*fun)(void *, void *), void *custom);
 
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -130,10 +130,8 @@ extern "C"
   LANTERN_API void *(LANTERN_PTR lantern_Tensor_undefined)();
   LANTERN_API void *(LANTERN_PTR lantern_Tensor_grad)(void *self);
   LANTERN_API bool(LANTERN_PTR lantern_Tensor_requires_grad)(void *self);
-  LANTERN_API void(LANTERN_PTR lantern_test_register_hook)();
   LANTERN_API void(LANTERN_PTR lantern_Tensor_register_hook)(void *self, void *hook);
   LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void *(*fun)(void *, void *), void *custom);
-  LANTERN_API void(LANTERN_PTR test_hooks)();
 
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);
@@ -2015,10 +2013,8 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(lantern_Tensor_undefined);
   LOAD_SYMBOL(lantern_Tensor_grad);
   LOAD_SYMBOL(lantern_Tensor_requires_grad);
-  LOAD_SYMBOL(lantern_test_register_hook);
   LOAD_SYMBOL(lantern_Tensor_register_hook);
   LOAD_SYMBOL(lantern_new_hook);
-  LOAD_SYMBOL(test_hooks);
 
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(lantern__cast_byte_tensor_bool)

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -130,6 +130,9 @@ extern "C"
   LANTERN_API void *(LANTERN_PTR lantern_Tensor_undefined)();
   LANTERN_API void *(LANTERN_PTR lantern_Tensor_grad)(void *self);
   LANTERN_API bool(LANTERN_PTR lantern_Tensor_requires_grad)(void *self);
+  LANTERN_API void(LANTERN_PTR lantern_test_register_hook)();
+  LANTERN_API void(LANTERN_PTR lantern_Tensor_register_hook)(void *self, void *hook);
+  LANTERN_API void *(LANTERN_PTR lantern_new_hook)(void *fun);
 
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);
@@ -2011,6 +2014,9 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(lantern_Tensor_undefined);
   LOAD_SYMBOL(lantern_Tensor_grad);
   LOAD_SYMBOL(lantern_Tensor_requires_grad);
+  LOAD_SYMBOL(lantern_test_register_hook);
+  LOAD_SYMBOL(lantern_Tensor_register_hook);
+  LOAD_SYMBOL(lantern_new_hook);
 
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(lantern__cast_byte_tensor_bool)

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -90,7 +90,7 @@ test_that("register_hook: can call a the hook inside a hook", {
     print("b")
   })
   
-  a$backward()
+  expect_output(a$backward(), "x.*b")
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -21,7 +21,6 @@ test_that("requires_grad works", {
 })
 
 test_that("register_hook", {
-  skip("skip test")
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { print("hello")})
   y <- 2 * x

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -78,19 +78,47 @@ test_that("register_hook: grad non leaf", {
 })
 
 test_that("register_hook: can call a the hook inside a hook", {
+  
+  v <- NULL
+  
   x <- torch_tensor(1, requires_grad = TRUE)
   y <- 2 * x
-  x$register_hook(function(grad) print("x"))
+  x$register_hook(function(grad) v <<- c(v, "x"))
   
   a <- torch_tensor(1, requires_grad = TRUE)
   b <- 2 * a
   a$register_hook(function(grad) {
-    print("a")
+    v <<- c(v, "a")
     y$backward()
-    print("b")
+  })
+  a$backward()
+  
+  expect_equal(v, c("a", "x"))
+  
+  v <- NULL
+  
+  x <- torch_tensor(1, requires_grad = TRUE)
+  y <- 2 * x
+  x$register_hook(function(grad) v <<- c(v, "x"))
+  
+  a <- torch_tensor(1, requires_grad = TRUE)
+  b <- 2 * a
+  a$register_hook(function(grad) {
+    v <<- c(v, "a")
+    y$backward()
   })
   
-  expect_output(a$backward(), "x.*b")
+  k <- torch_tensor(1, requires_grad = TRUE)
+  l <- 2 * k
+  k$register_hook(function(grad) {
+    v <<- c(v, "k")
+    a$backward()
+  })
+  
+  l$backward()
+  
+  expect_equal(v, c("k", "a", "x"))
+  
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -34,17 +34,28 @@ test_that("register_hook", {
   expect_output(y$backward(), "torch_tensor")
   
   x <- torch_tensor(c(2), requires_grad = TRUE)
+  x$register_hook(function(grad) { print("ABABA")})
+  y <- 2 * x
+  y$register_hook(function(grad) { print("EBEBE")})
+  expect_output(y$backward(), "EBEBE.*ABABA")
+})
+
+test_that("register hook: can throw exceptions in the lantern thread", {
+  skip_on_os("windows")
+  x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { 2* grad})
   y <- 2 * x
   y$backward()
   expect_equal_to_r(x$grad(), 4)
   expect_error(y$backward())
-  
+})
+
+test_that("register hook: can throw exceptions in the hook", {
+  skip_on_os("windows")
   x <- torch_tensor(c(2), requires_grad = TRUE)
-  x$register_hook(function(grad) { print("ABABA")})
+  x$register_hook(function(grad) { stop()})
   y <- 2 * x
-  y$register_hook(function(grad) { print("EBEBE")})
-  expect_output(y$backward(), "EBEBE.*ABABA")
+  expect_error(y$backward())
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -38,6 +38,7 @@ test_that("register_hook", {
   y <- 2 * x
   y$backward()
   expect_equal_to_r(x$grad(), 4)
+  expect_error(y$backward())
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -39,6 +39,12 @@ test_that("register_hook", {
   y$backward()
   expect_equal_to_r(x$grad(), 4)
   expect_error(y$backward())
+  
+  x <- torch_tensor(c(2), requires_grad = TRUE)
+  x$register_hook(function(grad) { print("ABABA")})
+  y <- 2 * x
+  y$register_hook(function(grad) { print("EBEBE")})
+  expect_output(y$backward(), "EBEBE.*ABABA")
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -1,8 +1,21 @@
 test_that("can autograd", {
   x <- torch_tensor(c(1), requires_grad = TRUE)
   y <- 2 * x
-  expect_invisible(y$backward())
   
+  expect_invisible(y$backward())
+  expect_equal_to_r(x$grad(), 2)
+})
+
+test_that("can autograd with contexts", {
+
+  with_no_grad({
+    with_enable_grad({
+      x <- torch_tensor(c(1), requires_grad = TRUE)
+      y <- 2 * x
+    })
+  })
+
+  expect_invisible(y$backward())
   expect_equal_to_r(x$grad(), 2)
 })
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -24,8 +24,8 @@ test_that("register_hook", {
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { print("hello")})
   y <- 2 * x
-  y$backward()
-  x$grad()
+  expect_output(y$backward(), "hello")
+  expect_equal_to_r(x$grad(), 2)
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -77,5 +77,21 @@ test_that("register_hook: grad non leaf", {
   expect_equal_to_r(x$grad(), c(1,0,0,0,0))
 })
 
+test_that("register_hook: can call a the hook inside a hook", {
+  skip("not working yet")
+  x <- torch_tensor(1, requires_grad = TRUE)
+  y <- 2 * x
+  x$register_hook(function(grad) print("x"))
+  
+  a <- torch_tensor(1, requires_grad = TRUE)
+  b <- 2 * a
+  a$register_hook(function(grad) {
+    print("a")
+    y$backward()
+    print("b")
+  })
+  
+  a$backward()
+})
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -22,7 +22,7 @@ test_that("requires_grad works", {
 
 test_that("register_hook", {
   x <- torch_tensor(c(1), requires_grad = TRUE)
-  cpp_tensor_register_hook(x$ptr)
+  x$register_hook(function(grad) { print("hello")})
   y <- 2 * x
   y$backward()
   x$grad()

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -41,7 +41,7 @@ test_that("register_hook", {
 })
 
 test_that("register hook: can throw exceptions in the lantern thread", {
-  skip_on_os("windows")
+  skip("skip test")
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { 2* grad})
   y <- 2 * x
@@ -51,7 +51,7 @@ test_that("register hook: can throw exceptions in the lantern thread", {
 })
 
 test_that("register hook: can throw exceptions in the hook", {
-  skip_on_os("windows")
+  skip("skip test")
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { stop()})
   y <- 2 * x

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -21,7 +21,8 @@ test_that("requires_grad works", {
 })
 
 test_that("register_hook", {
-  x <- torch_tensor(c(1), requires_grad = TRUE)
+  skip("skip test")
+  x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { print("hello")})
   y <- 2 * x
   y$backward()

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -26,6 +26,18 @@ test_that("register_hook", {
   y <- 2 * x
   expect_output(y$backward(), "hello")
   expect_equal_to_r(x$grad(), 2)
+  
+  # correctly sees the gradient
+  x <- torch_tensor(c(2), requires_grad = TRUE)
+  x$register_hook(function(grad) { print(grad)})
+  y <- 2 * x
+  expect_output(y$backward(), "torch_tensor")
+  
+  x <- torch_tensor(c(2), requires_grad = TRUE)
+  x$register_hook(function(grad) { 2* grad})
+  y <- 2 * x
+  y$backward()
+  expect_equal_to_r(x$grad(), 4)
 })
 
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -20,4 +20,13 @@ test_that("requires_grad works", {
   expect_true(!x$requires_grad())
 })
 
+test_that("register_hook", {
+  x <- torch_tensor(c(1), requires_grad = TRUE)
+  cpp_tensor_register_hook(x$ptr)
+  y <- 2 * x
+  y$backward()
+  x$grad()
+})
+
+
 

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -2,17 +2,17 @@ test_that("can autograd", {
   x <- torch_tensor(c(1), requires_grad = TRUE)
   y <- 2 * x
   expect_invisible(y$backward())
-  
+
   expect_equal_to_r(x$grad(), 2)
 })
 
 test_that("requires_grad works", {
   x <- torch_tensor(c(1), requires_grad = TRUE)
   expect_true(x$requires_grad())
-  
+
   x <- torch_tensor(c(1), requires_grad = FALSE)
   expect_true(!x$requires_grad())
-  
+
   x <- torch_tensor(c(1), requires_grad = FALSE)
   x$requires_grad_(TRUE)
   expect_true(x$requires_grad())
@@ -26,13 +26,13 @@ test_that("register_hook", {
   y <- 2 * x
   expect_output(y$backward(), "hello")
   expect_equal_to_r(x$grad(), 2)
-  
+
   # correctly sees the gradient
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { print(grad)})
   y <- 2 * x
   expect_output(y$backward(), "torch_tensor")
-  
+
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { print("ABABA")})
   y <- 2 * x
@@ -72,13 +72,12 @@ test_that("register_hook: grad non leaf", {
   }
   x0$register_hook(hook)
   x_list[[1]]$backward()
-  
+
   expect_equal_to_r(hook_results, 1)
   expect_equal_to_r(x$grad(), c(1,0,0,0,0))
 })
 
 test_that("register_hook: can call a the hook inside a hook", {
-  skip("not working yet")
   x <- torch_tensor(1, requires_grad = TRUE)
   y <- 2 * x
   x$register_hook(function(grad) print("x"))

--- a/tools/torchgen/R/cpp.R
+++ b/tools/torchgen/R/cpp.R
@@ -425,7 +425,8 @@ SKIP_R_BINDIND <- c(
   "set_quantizer_", #https://github.com/pytorch/pytorch/blob/5dfcfeebb89304c1e7978cad7ada1227f19303f6/tools/autograd/gen_python_functions.py#L36
   "normal",
   "polygamma",
-  "_nnpack_available"
+  "_nnpack_available",
+  "backward"
 )
 
 cpp <- function(path) {


### PR DESCRIPTION
This PR turned out to be more complex than expected.

Since hooks are arbitrary R functions, they must run in the main
thread, but `backward` can call them from other threads..  In order to make sure, 
we call `backward` in a different thread
see `cpp_backward` and leave the main thread free to execute the R
calbacks that are pushed to the `event_loop_thread` as `packaged_tasks` to the `tasks` global.

However, the R hooks can by themselves call `backward` again and torch
does not allow us to use a different thread. so while we are waiting for
the hook to finish, we allow to execute tasks in the thread
the hook has been called.