### PR TITLE
Do not install prebuilt torch in linux tests

### DIFF
--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -1,10 +1,12 @@
 name: Lantern
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request'}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request'}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Install dependencies
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Build lantern and get libtorch
+        if: matrix.install != 1
         run: | 
           Rscript tools/buildlantern.R
       - name: Check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,12 +15,16 @@ jobs:
         include:
           - os: ubuntu-18.04
             cran: https://demo.rstudiopm.com/all/__linux__/bionic/latest
+          - os: macos-latest
+            install: 1
+          - os: windows-latest
+            install: 1
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
     timeout-minutes: 30
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      INSTALL_TORCH: 1
+      INSTALL_TORCH: 1${{ matrix.install }}
       CRAN: ${{ matrix.cran }}
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 30
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      INSTALL_TORCH: 1${{ matrix.install }}
+      INSTALL_TORCH: ${{ matrix.install }}
       CRAN: ${{ matrix.cran }}
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: "0 1 * * *"


### PR DESCRIPTION
- Lantern build now only runs in master.
- PR avoid duplicate Test builds by running only on PRs and push to master.
- The Linux test always builds lantern but the windows and OS X do not.