### PR TITLE
Auto-install GPU version when CUDA detected and avoid prompts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,8 +17,11 @@ jobs:
         include:
           - os: ubuntu-18.04
             cran: https://demo.rstudiopm.com/all/__linux__/bionic/latest
-          - os: ubuntu-18.04
             install: 0
+          - os: macos-latest
+            install: 1
+          - os: windows-latest
+            install: 1
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,10 +17,8 @@ jobs:
         include:
           - os: ubuntu-18.04
             cran: https://demo.rstudiopm.com/all/__linux__/bionic/latest
-          - os: macos-latest
-            install: 1
-          - os: windows-latest
-            install: 1
+          - os: ubuntu-18.04
+            install: 0
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
     timeout-minutes: 30
@@ -59,7 +57,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request'}}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      INSTALL_TORCH: 1
       CRAN: https://demo.rstudiopm.com/all/__linux__/bionic/latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Build lantern and get libtorch
-        if: matrix.install != 1
+        if: matrix.install == 0
         run: | 
           Rscript tools/buildlantern.R
       - name: Check

--- a/R/install.R
+++ b/R/install.R
@@ -155,4 +155,7 @@ install_torch <- function(version = "1.5.0", type = install_type(version = versi
   }
   
   lantern_install_libs(version, type, path)
+  
+  # reinitialize lantern, might happen if installation fails on load and manual install required
+  lantern_start(reload = TRUE)
 }

--- a/R/install.R
+++ b/R/install.R
@@ -145,7 +145,7 @@ install_type <- function(version) {
 #' 
 #' @export
 install_torch <- function(version = "1.5.0", type = install_type(version = version), reinstall = FALSE,
-                          path = install_path()) {
+                          path = install_path(), ...) {
   if (reinstall) {
     unlink(path, recursive = TRUE)
   }
@@ -157,5 +157,6 @@ install_torch <- function(version = "1.5.0", type = install_type(version = versi
   lantern_install_libs(version, type, path)
   
   # reinitialize lantern, might happen if installation fails on load and manual install required
-  lantern_start(reload = TRUE)
+  if (!identical(list(...)$load, FALSE))
+    lantern_start(reload = TRUE)
 }

--- a/R/lantern_load.R
+++ b/R/lantern_load.R
@@ -5,12 +5,12 @@ lantern_default <- function() {
   "1.4.0" 
 }
 
-lantern_start <- function(version = lantern_default()) {
+lantern_start <- function(version = lantern_default(), reload = FALSE) {
   if (!install_exists()) {
     stop("Torch is not installed, please run 'install_torch()'.")
   }
   
-  if (.globals$lantern_started) return()
+  if (.globals$lantern_started && !reload) return()
   
   cpp_lantern_init(install_path())
   

--- a/R/package.R
+++ b/R/package.R
@@ -8,16 +8,22 @@ NULL
 }
 
 .onLoad <- function(libname, pkgname){
+  install_success <- TRUE
   if (!install_exists() && !Sys.getenv("INSTALL_TORCH", unset = 1) == 0) {
-    install_torch()
+    install_success <- tryCatch({
+      install_torch()
+      TRUE
+    }, error = function(e) {
+      warning("Failed to install Torch, manually run install_torch(). ", e$message, call. = FALSE)
+      FALSE
+    })
   }
     
-  if (install_exists()) {
+  if (install_exists() && install_success) {
     lantern_start() 
     .generator_null <<- torch_generator()
     .generator_null$set_current_seed(seed = abs(.Random.seed[1]))
   }
-  
 }
 
 .onUnload <- function(libpath) {

--- a/R/package.R
+++ b/R/package.R
@@ -6,21 +6,11 @@ NULL
 
 .onAttach <- function(libname, pkgname) {
   if (!install_exists() && interactive()) {
-    packageStartupMessage("You need to install libtorch in order to use torch.\n")
-    ans <- readline("Do you want to download it now? ~100Mb (yes/no)")
-    if (ans == "yes" | ans == "y")
-      install_torch()
-    
-    if (install_exists()) {
-      packageStartupMessage("Torch was successfully installed.")
-      packageStartupMessage("Please restart your R session now.")
-    }
-      
+    install_torch()
   }
 }
 
 .onLoad <- function(libname, pkgname){
-  
   if (!install_exists() && Sys.getenv("INSTALL_TORCH", unset = 0) == 1) {
     install_torch()
   }

--- a/R/package.R
+++ b/R/package.R
@@ -9,7 +9,7 @@ NULL
 
 .onLoad <- function(libname, pkgname){
   install_success <- TRUE
-  if (!install_exists() && !Sys.getenv("INSTALL_TORCH", unset = 1) == 0) {
+  if (!install_exists() && Sys.getenv("INSTALL_TORCH", unset = 1) != 0) {
     install_success <- tryCatch({
       install_torch()
       TRUE
@@ -19,7 +19,7 @@ NULL
     })
   }
     
-  if (install_exists() && install_success) {
+  if (install_exists() && install_success && Sys.getenv("LOAD_TORCH", unset = 1) != 0) {
     lantern_start() 
     .generator_null <<- torch_generator()
     .generator_null$set_current_seed(seed = abs(.Random.seed[1]))

--- a/R/package.R
+++ b/R/package.R
@@ -20,9 +20,15 @@ NULL
   }
     
   if (install_exists() && install_success && Sys.getenv("LOAD_TORCH", unset = 1) != 0) {
-    lantern_start() 
-    .generator_null <<- torch_generator()
-    .generator_null$set_current_seed(seed = abs(.Random.seed[1]))
+    # in case init fails aallow user to restart session rather than blocking install
+    tryCatch({
+      lantern_start() 
+      .generator_null <<- torch_generator()
+      .generator_null$set_current_seed(seed = abs(.Random.seed[1]))
+    }, error = function(e) {
+      warning("Torch failed to start, restart your R session to try again. ", e$message, call. = FALSE)
+      FALSE
+    })
   }
 }
 

--- a/R/package.R
+++ b/R/package.R
@@ -5,13 +5,10 @@ NULL
 .generator_null <- NULL
 
 .onAttach <- function(libname, pkgname) {
-  if (!install_exists() && interactive()) {
-    install_torch()
-  }
 }
 
 .onLoad <- function(libname, pkgname){
-  if (!install_exists() && Sys.getenv("INSTALL_TORCH", unset = 0) == 1) {
+  if (!install_exists() && !Sys.getenv("INSTALL_TORCH", unset = 1) == 0) {
     install_torch()
   }
     

--- a/tools/buildlantern.R
+++ b/tools/buildlantern.R
@@ -20,7 +20,7 @@ if (dir.exists("lantern")) {
   
   # download torch
   source("R/install.R")
-  install_torch(path = normalizePath("deps/"))
+  install_torch(path = normalizePath("deps/"), load = FALSE)
   
   # copy deps to inst
   if (fs::dir_exists("inst/deps"))


### PR DESCRIPTION
- Auto-install GPU version when CUDA detected.
- Avoid installation prompts. There is precedent where binaries are downloaded when a package is built in Windows. 99% of the users will want to install Torch when the package loads, so we would be doing them a disservice if we prompt all the time. CRAN does not allow installing anything outside the package folder, but in this case, Torch and Lantern are being installed in the package folder, so it should be all good! Hopefully!