### PR TITLE
Add support for TORCH_HOME to fix #90

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -142,8 +142,18 @@ install_type <- function(version) {
   if (nchar(Sys.getenv("CUDA")) > 0) return(Sys.getenv("CUDA"))
   if (install_os() != "linux") return("cpu")
   
-  versions_file <- "/usr/local/cuda/version.txt"
-  if (!file.exists(versions_file)) return("cpu")
+  versions_file <- NULL
+  cuda_home <- Sys.getenv("CUDA_HOME")
+  
+  if (nchar(cuda_home) > 0) {
+    versions_file <- file.path(cuda_home, "version.txt")
+    if (!file.exists(versions_file)) versions_file <- NULL
+  }
+  
+  if (is.null(versions_file)) {
+    versions_file <- "/usr/local/cuda/version.txt"
+    if (!file.exists(versions_file)) return("cpu")
+  }
   
   cuda_version <- gsub("CUDA Version |\\.[0-9]+$", "", readLines(versions_file))
   versions_available <- names(install_config[[version]])

--- a/R/install.R
+++ b/R/install.R
@@ -40,8 +40,30 @@ install_config <- list(
 
 #' @keywords internal
 #' @export
-install_path <- function() {
-  normalizePath(file.path(system.file("", package = "torch"), "deps"), mustWork = FALSE)
+install_path <- function(version = "1.5.0") {
+  path <- Sys.getenv("TORCH_HOME")
+  if (nchar(path) > 0) {
+    if (!dir.exists(path)) {
+      warning("The TORCH_HOME path does not exists.")
+      path <- ""
+    }
+    else {
+      install_info <- install_config[[version]][["cpu"]][[install_os()]]
+      for (library_name in names(install_info)) {
+        if (!lib_installed(library_name, path)) {
+          warning("The TORCH_HOME path is missing the '", library_name, "' library.")
+          path <- ""
+        }
+      }
+    }
+  }
+  
+  if (nchar(path) > 0) {
+    path
+  }
+  else {
+    normalizePath(file.path(system.file("", package = "torch"), "deps"), mustWork = FALSE)
+  }
 }
 
 install_exists <- function() {
@@ -142,6 +164,14 @@ install_type <- function(version) {
 #' @param type The installation type for Torch. Valid values are \code{"cpu"} or the 'CUDA' version.
 #' @param reinstall Re-install Torch even if its already installed?
 #' @param path Optional path to install or check for an already existing installation.
+#' 
+#' @details 
+#' 
+#' When using \code{path} to install in a specific location, make sure the \code{TORCH_HOME} environment
+#' variable is set to this same path to reuse this installation. The \code{TORCH_INSTALL} environment
+#' variable can be set to \code{0} to prevent auto-installing torch and \code{TORCH_LOAD} set to \code{0}
+#' to avoid loading dependencies automatically. These environment variables are meant for advanced use
+#' cases and troubleshootinng only.
 #' 
 #' @export
 install_torch <- function(version = "1.5.0", type = install_type(version = version), reinstall = FALSE,

--- a/R/lantern_load.R
+++ b/R/lantern_load.R
@@ -12,7 +12,7 @@ lantern_start <- function(version = lantern_default(), reload = FALSE) {
   
   if (.globals$lantern_started && !reload) return()
   
-  cpp_lantern_init(install_path())
+  cpp_lantern_init(normalizePath(install_path()))
   
   .globals$lantern_started <- TRUE
 }

--- a/R/package.R
+++ b/R/package.R
@@ -9,7 +9,7 @@ NULL
 
 .onLoad <- function(libname, pkgname){
   install_success <- TRUE
-  if (!install_exists() && Sys.getenv("INSTALL_TORCH", unset = 1) != 0) {
+  if (!install_exists() && Sys.getenv("TORCH_INSTALL", unset = 1) != 0) {
     install_success <- tryCatch({
       install_torch()
       TRUE
@@ -19,7 +19,7 @@ NULL
     })
   }
     
-  if (install_exists() && install_success && Sys.getenv("LOAD_TORCH", unset = 1) != 0) {
+  if (install_exists() && install_success && Sys.getenv("TORCH_LOAD", unset = 1) != 0) {
     # in case init fails aallow user to restart session rather than blocking install
     tryCatch({
       lantern_start() 


### PR DESCRIPTION
Fix for https://github.com/mlverse/torch/issues/90 to avoid re-downloading over-and-over libtorch while doing development. The workflow is to run:

```r
# install torch in home path
Sys.setenv(TORCH_HOME = "~/torch")

# rebuild torch package
# libtorch will be downloaded to TORCH_HOME

# rebuild torch package
# libtorch is found in TORCH_HOME and nothing is downloaded
```

This workflow is not to be used by users, mostly for developers and/or very-advanced users.