### PR TITLE
Convert torch::Scalar to R types

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -7021,6 +7021,26 @@ cpp_torch_scalar <- function(x) {
     .Call('_torch_cpp_torch_scalar', PACKAGE = 'torchpkg', x)
 }
 
+cpp_torch_scalar_dtype <- function(self) {
+    .Call('_torch_cpp_torch_scalar_dtype', PACKAGE = 'torchpkg', self)
+}
+
+cpp_torch_scalar_to_int <- function(self) {
+    .Call('_torch_cpp_torch_scalar_to_int', PACKAGE = 'torchpkg', self)
+}
+
+cpp_torch_scalar_to_double <- function(self) {
+    .Call('_torch_cpp_torch_scalar_to_double', PACKAGE = 'torchpkg', self)
+}
+
+cpp_torch_scalar_to_float <- function(self) {
+    .Call('_torch_cpp_torch_scalar_to_float', PACKAGE = 'torchpkg', self)
+}
+
+cpp_torch_scalar_to_bool <- function(self) {
+    .Call('_torch_cpp_torch_scalar_to_bool', PACKAGE = 'torchpkg', self)
+}
+
 cpp_torch_tensor_print <- function(x) {
     invisible(.Call('_torch_cpp_torch_tensor_print', PACKAGE = 'torchpkg', x))
 }

--- a/R/codegen-utils.R
+++ b/R/codegen-utils.R
@@ -156,7 +156,7 @@ to_return_type <- function(res, types) {
       return(torch_dtype$new(ptr = res))
     
     if (dtype == "Scalar")
-      return(Scalar$new(ptr = res))
+      return(Scalar$new(ptr = res)$to_r())
     
   }
   

--- a/R/codegen-utils.R
+++ b/R/codegen-utils.R
@@ -154,6 +154,10 @@ to_return_type <- function(res, types) {
     
     if (dtype == "ScalarType")
       return(torch_dtype$new(ptr = res))
+    
+    if (dtype == "Scalar")
+      return(Scalar$new(ptr = res))
+    
   }
   
   if (length(types) == 1) {

--- a/R/scalar.R
+++ b/R/scalar.R
@@ -14,8 +14,32 @@ Scalar <- R6::R6Class(
       
       self$ptr <- cpp_torch_scalar(x);
       
+    },
+    
+    to_r = function() {
+      
+      type <- self$type
+      
+      if (type == torch_double())
+        f <- cpp_torch_scalar_to_double
+      else if (type == torch_float())
+        f <- cpp_torch_scalar_to_float
+      else if (type == torch_bool())
+        f <- cpp_torch_scalar_to_bool
+      else if (type == torch_int())
+        f <- cpp_torch_scalar_to_int
+      else if (type == torch_long())
+        f <- cpp_torch_scalar_to_int
+      
+      f(self$ptr)
     }
     
+  ),
+  
+  active = list(
+    type = function() {
+      torch_dtype$new(ptr = cpp_torch_scalar_dtype(self$ptr))
+    }
   )
   
 )

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -2211,11 +2211,11 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(lantern_nn_utils_rnn_pad_packed_sequence);
   LOAD_SYMBOL(lantern_nn_utils_rnn_pad_sequence);
   LOAD_SYMBOL(lantern_nn_utils_rnn_PackedSequence_new);
-  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_dtype);
-  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_float);
-  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_int);
-  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_double);
-  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_bool);
+  LOAD_SYMBOL(lantern_Scalar_dtype);
+  LOAD_SYMBOL(lantern_Scalar_to_float);
+  LOAD_SYMBOL(lantern_Scalar_to_int);
+  LOAD_SYMBOL(lantern_Scalar_to_double);
+  LOAD_SYMBOL(lantern_Scalar_to_bool);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(lantern__cast_char_tensor_bool)

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -200,6 +200,11 @@ extern "C"
                                                                            double padding_value, void *total_length);
   LANTERN_API void *(LANTERN_PTR lantern_nn_utils_rnn_pad_sequence)(void *sequence, bool batch_first, double padding_value);
   LANTERN_API void *(LANTERN_PTR lantern_nn_utils_rnn_PackedSequence_new)(void *data, void *batch_sizes, void *sorted_indices, void *unsorted_indices);
+  LANTERN_API void *(LANTERN_PTR lantern_Scalar_dtype)(void *self);
+  LANTERN_API float(LANTERN_PTR lantern_Scalar_to_float)(void *self);
+  LANTERN_API int(LANTERN_PTR lantern_Scalar_to_int)(void *self);
+  LANTERN_API double(LANTERN_PTR lantern_Scalar_to_double)(void *self);
+  LANTERN_API bool(LANTERN_PTR lantern_Scalar_to_bool)(void *self);
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);
   LANTERN_API void *(LANTERN_PTR lantern__cast_char_tensor_bool)(void *self, void *non_blocking);
@@ -2206,6 +2211,11 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(lantern_nn_utils_rnn_pad_packed_sequence);
   LOAD_SYMBOL(lantern_nn_utils_rnn_pad_sequence);
   LOAD_SYMBOL(lantern_nn_utils_rnn_PackedSequence_new);
+  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_dtype);
+  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_float);
+  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_int);
+  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_double);
+  LOAD_SYMBOL(LANTERN_PTR lantern_Scalar_to_bool);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(lantern__cast_char_tensor_bool)

--- a/lantern/src/Scalar.cpp
+++ b/lantern/src/Scalar.cpp
@@ -29,6 +29,36 @@ void *lantern_Scalar(void *value, const char *type)
   return (void *)new LanternObject<torch::Scalar>(out);
 }
 
+void *lantern_Scalar_dtype(void *self)
+{
+  auto v = reinterpret_cast<LanternObject<torch::Scalar> *>(self)->get();
+  return (void *)new LanternObject<torch::Dtype>(v.type());
+}
+
+float lantern_Scalar_to_float(void *self)
+{
+  auto v = reinterpret_cast<LanternObject<torch::Scalar> *>(self)->get();
+  return v.toFloat();
+}
+
+int lantern_Scalar_to_int(void *self)
+{
+  auto v = reinterpret_cast<LanternObject<torch::Scalar> *>(self)->get();
+  return v.toInt();
+}
+
+double lantern_Scalar_to_double(void *self)
+{
+  auto v = reinterpret_cast<LanternObject<torch::Scalar> *>(self)->get();
+  return v.toDouble();
+}
+
+bool lantern_Scalar_to_bool(void *self)
+{
+  auto v = reinterpret_cast<LanternObject<torch::Scalar> *>(self)->get();
+  return v.toBool();
+}
+
 void *lantern_Scalar_nullopt()
 {
   return (void *)new LanternObject<c10::optional<torch::Scalar>>(c10::nullopt);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23374,6 +23374,61 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_torch_scalar_dtype
+Rcpp::XPtr<XPtrTorchScalarType> cpp_torch_scalar_dtype(Rcpp::XPtr<XPtrTorchScalar> self);
+RcppExport SEXP _torch_cpp_torch_scalar_dtype(SEXP selfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchScalar> >::type self(selfSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_torch_scalar_dtype(self));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_torch_scalar_to_int
+int cpp_torch_scalar_to_int(Rcpp::XPtr<XPtrTorchScalar> self);
+RcppExport SEXP _torch_cpp_torch_scalar_to_int(SEXP selfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchScalar> >::type self(selfSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_torch_scalar_to_int(self));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_torch_scalar_to_double
+double cpp_torch_scalar_to_double(Rcpp::XPtr<XPtrTorchScalar> self);
+RcppExport SEXP _torch_cpp_torch_scalar_to_double(SEXP selfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchScalar> >::type self(selfSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_torch_scalar_to_double(self));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_torch_scalar_to_float
+float cpp_torch_scalar_to_float(Rcpp::XPtr<XPtrTorchScalar> self);
+RcppExport SEXP _torch_cpp_torch_scalar_to_float(SEXP selfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchScalar> >::type self(selfSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_torch_scalar_to_float(self));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_torch_scalar_to_bool
+bool cpp_torch_scalar_to_bool(Rcpp::XPtr<XPtrTorchScalar> self);
+RcppExport SEXP _torch_cpp_torch_scalar_to_bool(SEXP selfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchScalar> >::type self(selfSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_torch_scalar_to_bool(self));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_torch_tensor_print
 void cpp_torch_tensor_print(Rcpp::XPtr<XPtrTorchTensor> x);
 RcppExport SEXP _torch_cpp_torch_tensor_print(SEXP xSEXP) {
@@ -25320,6 +25375,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_torch_reduction_none", (DL_FUNC) &_torch_cpp_torch_reduction_none, 0},
     {"_torch_cpp_torch_reduction_sum", (DL_FUNC) &_torch_cpp_torch_reduction_sum, 0},
     {"_torch_cpp_torch_scalar", (DL_FUNC) &_torch_cpp_torch_scalar, 1},
+    {"_torch_cpp_torch_scalar_dtype", (DL_FUNC) &_torch_cpp_torch_scalar_dtype, 1},
+    {"_torch_cpp_torch_scalar_to_int", (DL_FUNC) &_torch_cpp_torch_scalar_to_int, 1},
+    {"_torch_cpp_torch_scalar_to_double", (DL_FUNC) &_torch_cpp_torch_scalar_to_double, 1},
+    {"_torch_cpp_torch_scalar_to_float", (DL_FUNC) &_torch_cpp_torch_scalar_to_float, 1},
+    {"_torch_cpp_torch_scalar_to_bool", (DL_FUNC) &_torch_cpp_torch_scalar_to_bool, 1},
     {"_torch_cpp_torch_tensor_print", (DL_FUNC) &_torch_cpp_torch_tensor_print, 1},
     {"_torch_cpp_torch_tensor_dtype", (DL_FUNC) &_torch_cpp_torch_tensor_dtype, 1},
     {"_torch_cpp_torch_tensor", (DL_FUNC) &_torch_cpp_torch_tensor, 4},

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -200,6 +200,11 @@ extern "C"
                                                                            double padding_value, void *total_length);
   LANTERN_API void *(LANTERN_PTR lantern_nn_utils_rnn_pad_sequence)(void *sequence, bool batch_first, double padding_value);
   LANTERN_API void *(LANTERN_PTR lantern_nn_utils_rnn_PackedSequence_new)(void *data, void *batch_sizes, void *sorted_indices, void *unsorted_indices);
+  LANTERN_API void *(LANTERN_PTR lantern_Scalar_dtype)(void *self);
+  LANTERN_API float(LANTERN_PTR lantern_Scalar_to_float)(void *self);
+  LANTERN_API int(LANTERN_PTR lantern_Scalar_to_int)(void *self);
+  LANTERN_API double(LANTERN_PTR lantern_Scalar_to_double)(void *self);
+  LANTERN_API bool(LANTERN_PTR lantern_Scalar_to_bool)(void *self);
   /* Autogen Headers -- Start */
   LANTERN_API void *(LANTERN_PTR lantern__cast_byte_tensor_bool)(void *self, void *non_blocking);
   LANTERN_API void *(LANTERN_PTR lantern__cast_char_tensor_bool)(void *self, void *non_blocking);
@@ -2206,6 +2211,11 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(lantern_nn_utils_rnn_pad_packed_sequence);
   LOAD_SYMBOL(lantern_nn_utils_rnn_pad_sequence);
   LOAD_SYMBOL(lantern_nn_utils_rnn_PackedSequence_new);
+  LOAD_SYMBOL(lantern_Scalar_dtype);
+  LOAD_SYMBOL(lantern_Scalar_to_float);
+  LOAD_SYMBOL(lantern_Scalar_to_int);
+  LOAD_SYMBOL(lantern_Scalar_to_double);
+  LOAD_SYMBOL(lantern_Scalar_to_bool);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(lantern__cast_char_tensor_bool)

--- a/src/scalar.cpp
+++ b/src/scalar.cpp
@@ -35,3 +35,34 @@ Rcpp::XPtr<XPtrTorchScalar> cpp_torch_scalar (SEXP x) {
 
   return make_xptr<XPtrTorchScalar>(out);
 }
+
+// [[Rcpp::export]]
+Rcpp::XPtr<XPtrTorchScalarType> cpp_torch_scalar_dtype (Rcpp::XPtr<XPtrTorchScalar> self)
+{
+  XPtrTorchScalarType out = lantern_Scalar_dtype(self->get());
+  return make_xptr<XPtrTorchScalarType>(out);
+}
+
+// [[Rcpp::export]]
+int cpp_torch_scalar_to_int (Rcpp::XPtr<XPtrTorchScalar> self) 
+{
+  return lantern_Scalar_to_int(self->get());
+}
+
+// [[Rcpp::export]]
+double cpp_torch_scalar_to_double (Rcpp::XPtr<XPtrTorchScalar> self)
+{
+  return lantern_Scalar_to_double(self->get());
+}
+
+// [[Rcpp::export]]
+float cpp_torch_scalar_to_float (Rcpp::XPtr<XPtrTorchScalar> self)
+{
+  return lantern_Scalar_to_float(self->get());
+}
+
+// [[Rcpp::export]]
+bool cpp_torch_scalar_to_bool (Rcpp::XPtr<XPtrTorchScalar> self)
+{
+  return lantern_Scalar_to_bool(self->get());
+}

--- a/tests/testthat/test-gen-method.R
+++ b/tests/testthat/test-gen-method.R
@@ -9,3 +9,21 @@ test_that("__and__", {
   expect_tensor(y)
   expect_equal_to_tensor(y, x)
 })
+
+test_that("item", {
+  
+  x <- torch_tensor(1)
+  expect_equal(x$item(), 1)
+  
+  x <- torch_tensor(1L)
+  expect_equal(x$item(), 1L)
+  
+  x <- torch_tensor(TRUE)
+  expect_equal(x$item(), TRUE)
+  
+  x <- torch_tensor(1.5)
+  expect_equal(x$item(), 1.5)
+  
+  x <- torch_tensor(1.5, dtype = torch_double())
+  expect_equal(x$item(), 1.5)
+})


### PR DESCRIPTION
This PR's adds automatic convertion between torch::Scalar's and R types. Fixes #78 