### PR TITLE
add vignette for custom datasets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,8 @@ Suggests:
     bit64,
     fs,
     palmerpenguins
+Remotes:
+    allisonhorst/palmerpenguins
 VignetteBuilder: knitr
 Collate: 
     'R7.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Suggests:
     knitr,
     rmarkdown,
     bit64,
-    fs
+    fs,
+    palmerpenguins
 VignetteBuilder: knitr
 Collate: 
     'R7.R'

--- a/vignettes/loading-data.Rmd
+++ b/vignettes/loading-data.Rmd
@@ -2,7 +2,7 @@
 title: "Loading data"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Creating tensors}
+  %\VignetteIndexEntry{Loading data}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-#library(torch)
+library(torch)
 ```
 
 ## Datasets and data loaders
@@ -59,10 +59,7 @@ your own `dataset` to train on [Allison Horst\'s penguins](https://github.com/al
 ## A custom dataset
 
 ```{r}
-# remotes::install_github("allisonhorst/palmerpenguins")
 library(palmerpenguins)
-library(dplyr)
-library(purrr)
 
 penguins
 ```
@@ -103,11 +100,14 @@ penguins_dataset <- dataset(
   },
   
   prepare_penguin_data = function() {
+    
+    input <- na.omit(penguins) 
     # conveniently, the categorical data are already factors
-    input <- na.omit(penguins) %>%
-      mutate_if(is.factor, compose(partial(`-`, ... = , 1), as.integer)) %>%
-      # mutate_if(is.factor, as.integer) %>%
-      as.matrix()
+    input$species <- as.numeric(input$species) - 1
+    input$island <- as.numeric(input$island) - 1
+    input$sex <- as.numeric(input$sex) - 1
+    
+    input <- as.matrix(input)
     torch_tensor(input)
   }
 )

--- a/vignettes/loading-data.Rmd
+++ b/vignettes/loading-data.Rmd
@@ -1,0 +1,198 @@
+---
+title: "Loading data"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Creating tensors}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+#library(torch)
+```
+
+## Datasets and data loaders
+
+Central to data ingestion and preprocessing are datasets and data loaders.
+
+`torch` comes equipped with a bag of datasets related to, mostly, image recognition and natural language processing (e.g.,
+`mnist_dataset()`), which can be iterated over by means of `dataloader`s:
+
+```{r, eval = FALSE}
+# ...
+ds <- mnist_dataset(
+  dir, 
+  download = TRUE, 
+  transform = function(x) {
+    x <- x$to(dtype = torch_float())/256
+    x[newaxis,..]
+  }
+)
+
+dl <- dataloader(ds, batch_size = 32, shuffle = TRUE)
+
+for (b in enumerate(dl)) {
+  # ...
+
+```
+
+Cf. `vignettes/examples/mnist-cnn.R` for a complete example.
+
+What if you want to train on a different dataset? In these cases, you subclass `Dataset`, an abstract container that needs to
+know how to iterate over the given data. To that purpose, your subclass needs to implement `.getitem()`, and say what should
+be returned when the data loader is asking for the next batch.
+
+In `.getitem()`, you can implement whatever preprocessing you require. Additionally, you should implement `.length()`, so
+users can find out how many items there are in the dataset.
+
+While this may sound complicated, it is not at all. The base logic is straightforward -- complexity will, naturally, correlate
+with how involved your preprocessing is. To provide you with a simple but functional prototype, here we show how to create
+your own `dataset` to train on [Allison Horst\'s penguins](https://github.com/allisonhorst/palmerpenguins).
+
+## A custom dataset
+
+```{r}
+# remotes::install_github("allisonhorst/palmerpenguins")
+library(palmerpenguins)
+library(dplyr)
+library(purrr)
+
+penguins
+```
+
+`Dataset`s are R6 classes created using the `dataset()` constructor. You can pass a `name` and various member functions. Among
+those should be `initialize()`, to create instance variables, `.getitem()`, to indicate how the data should be returned, and
+`.length()`, to say how many items we have.
+
+In addition, any number of helper functions can be defined.
+
+Here, we assume the `penguins` have already been loaded, and all preprocessing consists in removing lines with `NA` values,
+transforming `factor`s to numbers starting from 0, and converting from R data types to `torch` tensors.
+
+In `.getitem`, we essentially decide how this data is going to be used: All variables besides `species` go into `x`, the
+predictor, and `species` will constitute `y`, the target. Predictor and target are returned in a list, to be accessed as
+`batch[[1]]` and `batch[[2]]` during training.
+
+```{r}
+penguins_dataset <- dataset(
+  
+  name = "penguins_dataset",
+  
+  initialize = function() {
+    self$data <- prepare_penguin_data()
+  },
+  
+  .getitem = function(index) {
+    
+    # tbd replace following https://github.com/mlverse/torch/issues/135
+    x <- self$data[index, 2:N]
+    y <- self$data[index, 1]$to(torch_long())
+    
+    list(x, y)
+  },
+  
+  .length = function() {
+    self$data$size()[[1]]
+  },
+  
+  prepare_penguin_data = function() {
+    # conveniently, the categorical data are already factors
+    input <- na.omit(penguins) %>%
+      mutate_if(is.factor, compose(partial(`-`, ... = , 1), as.integer)) %>%
+      # mutate_if(is.factor, as.integer) %>%
+      as.matrix()
+    torch_tensor(input)
+  }
+)
+
+```
+
+Let's create the dataset , query for it's length, and look at its first item:
+
+```{r}
+tuxes <- penguins_dataset()
+tuxes$.length()
+tuxes$.getitem(1)
+```
+
+To be able to iterate over `tuxes`, we need a data loader (we override the default batch size of `1`):
+
+```{r}
+dl <-tuxes %>% dataloader(batch_size = 8)
+```
+
+Calling `.length()` on a data loader (as opposed to a dataset) will return the number of `batches` we have:
+
+```{r}
+dl$.length()
+```
+
+And we can create an iterator to inspect the first batch:
+
+```{r}
+iter <- dl$.iter()
+b <- iter$.next()
+b
+```
+
+To train a network, we can use `enumerate` to iterate over batches.
+
+## Training with data loaders
+
+Our example network is very simple. (In reality, we would want to treat `island` as the categorical variable it is, and either
+one-hot-encode or embed it.)
+
+```{r}
+net <- nn_module(
+  "PenguinNet",
+  initialize = function() {
+    self$fc1 <- nn_linear(6, 32)
+    self$fc2 <- nn_linear(32, 3)
+  },
+  forward = function(x) {
+    x %>% 
+      self$fc1() %>% 
+      nnf_relu() %>% 
+      self$fc2() %>% 
+      nnf_log_softmax(dim = 1)
+  }
+)
+
+model <- net()
+
+```
+
+We still need an optimizer:
+
+```{r}
+optimizer <- optim_sgd(model$parameters, lr = 0.01)
+```
+
+And we're ready to train:
+
+```{r}
+for (epoch in 1:10) {
+  
+  l <- c()
+  
+  for (b in enumerate(dl)) {
+    print(b[[2]])
+    optimizer$zero_grad()
+    output <- model(b[[1]])
+    loss <- nnf_nll_loss(output, b[[2]])
+    loss$backward()
+    optimizer$step()
+    l <- c(l, loss$item())
+  }
+  
+  cat(sprintf("Loss at epoch %d: %3f\n", epoch, mean(l)))
+}
+
+```

--- a/vignettes/loading-data.Rmd
+++ b/vignettes/loading-data.Rmd
@@ -60,6 +60,7 @@ your own `dataset` to train on [Allison Horst\'s penguins](https://github.com/al
 
 ```{r}
 library(palmerpenguins)
+library(magrittr)
 
 penguins
 ```
@@ -83,7 +84,7 @@ penguins_dataset <- dataset(
   name = "penguins_dataset",
   
   initialize = function() {
-    self$data <- prepare_penguin_data()
+    self$data <- self$prepare_penguin_data()
   },
   
   .getitem = function(index) {
@@ -183,7 +184,6 @@ for (epoch in 1:10) {
   l <- c()
   
   for (b in enumerate(dl)) {
-    print(b[[2]])
     optimizer$zero_grad()
     output <- model(b[[1]])
     loss <- nnf_nll_loss(output, b[[2]])


### PR DESCRIPTION
this was supposed to come nicely working ;-)))

But without "doing anything" ;-))) (as users do; meaning: no pulls, ..) `dataset()` stopped being found, and before that `prepare_penguin_data` wasn't found (((it all worked up to some point, apart from the training loop which I didn't get to test yet due to that sudden namespace thing)))

Perhaps you could just run it on your side and see if it works - at least until the training loop, where I might still hav to fix something? (I was suspecting that `purrr` inside the dataset was the culprit, but I definitely was already using `dplyr` before, and now it fails for me even without the call to `purrr`...)

I should perhaps add that I'm still using the `devtools::lload_all` workflow, not `install` (which idk if it should work by now)