### PR TITLE
Support to set exceptions into lantern

### DIFF
--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -43,6 +43,7 @@ extern "C"
 {
 #endif
 
+  LANTERN_API void(LANTERN_PTR lanternSetLastError)(const char*);
   LANTERN_API void(LANTERN_PTR lanternLastErrorClear)();
   LANTERN_API const char*(LANTERN_PTR lanternLastError)();
   LANTERN_API void(LANTERN_PTR lanternTest)();
@@ -2072,6 +2073,7 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   if (!lanternLoadLibrary(libPath, pError))
     return false;
 
+  LOAD_SYMBOL(lanternSetLastError);
   LOAD_SYMBOL(lanternLastErrorClear);
   LOAD_SYMBOL(lanternLastError);
   LOAD_SYMBOL(lanternTest);

--- a/lantern/src/Autograd.cpp
+++ b/lantern/src/Autograd.cpp
@@ -49,6 +49,14 @@ void *lantern_new_hook(void *(*fun)(void *, void *), void *custom)
 {
     auto out = [fun, custom](torch::Tensor grad) {
         auto out = (*fun)((void *)new LanternObject<torch::Tensor>(grad), custom);
+      
+        // Exceptions from the host need to be properly converted to handle different compilers
+        if (lanternLastError() != NULL) {
+          std::string last = lanternLastError();
+          lanternLastErrorClear();
+          throw last;
+        } 
+        
         auto ten = reinterpret_cast<LanternObject<torch::Tensor> *>(out)->get();
         return ten;
     };

--- a/lantern/src/lantern.cpp
+++ b/lantern/src/lantern.cpp
@@ -10,6 +10,11 @@
 
 std::string *pLanternLastError = NULL;
 
+void lanternSetLastError(const char* error)
+{
+  pLanternLastError = new std::string(error);
+}
+
 const char* lanternLastError()
 {
   if (pLanternLastError == NULL)

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -56,7 +56,6 @@ test_that("register_hook", {
 })
 
 test_that("register hook: can throw exceptions in the lantern thread", {
-  skip_on_os("windows")
   x <- torch_tensor(c(2), requires_grad = TRUE)
   x$register_hook(function(grad) { 2* grad})
   y <- 2 * x


### PR DESCRIPTION
This fix enables support for setting errors into lantern, this top support setting errors from the R worker thread back to lantern as part of a separate PR.