### PR TITLE
Resolves #164: Implement more R generic methods

### DIFF
--- a/R/operators.R
+++ b/R/operators.R
@@ -30,6 +30,16 @@
 }
 
 #' @export
+`%%.torch_tensor` <- function(e1, e2) {
+  torch_fmod(e1, e2)
+}
+
+#' @export
+`%/%.torch_tensor` <- function(e1, e2) {
+  torch_floor_divide(e1, e2)
+}
+
+#' @export
 `>=.torch_tensor` <- function(e1, e2) {
   torch_ge(e1, e2)
 }
@@ -57,6 +67,21 @@
 #' @export
 `!=.torch_tensor` <- function(e1, e2) {
   torch_ne(e1, e2)
+}
+
+#' @export
+`&.torch_tensor` <- function(e1, e2) {
+  torch_logical_and(e1, e2)
+}
+
+#' @export
+`|.torch_tensor` <- function(e1, e2) {
+  torch_logical_or(e1, e2)
+}
+
+#' @export
+`!.torch_tensor` <- function(x) {
+  torch_logical_not(x)
 }
 
 #' @export
@@ -89,7 +114,167 @@ as.double.torch_tensor <- function(x, ...) {
   as.double(as_array(x))
 }
 
+#' @export
+abs.torch_tensor <- function(x) {
+  torch_abs(x)
+}
 
+#' @export
+sign.torch_tensor <- function(x) {
+  torch_sign(x)
+}
 
+#' @export
+sqrt.torch_tensor <- function(x) {
+  torch_sqrt(x)
+}
 
+#' @export
+ceiling.torch_tensor <- function(x) {
+  torch_ceil(x)
+}
 
+#' @export
+floor.torch_tensor <- function(x) {
+  torch_floor(x)
+}
+
+#' @export
+trunc.torch_tensor <- function(x) {
+  torch_trunc(x)
+}
+
+#' @export
+cumsum.torch_tensor <- function(x) {
+  torch_cumsum(x, dim = 0)
+}
+
+#' @export
+log.torch_tensor <- function(x, base) {
+  if (!missing(base)) {
+    torch_log(x)/torch_log(base)
+  } else {
+    torch_log(x)
+  }
+}
+
+#' @export
+log10.torch_tensor <- function(x) {
+  torch_log10(x)
+}
+
+#' @export
+log2.torch_tensor <- function(x) {
+  torch_log2(x)
+}
+
+#' @export
+log1p.torch_tensor <- function(x) {
+  torch_log1p(x)
+}
+
+#' @export
+acos.torch_tensor <- function(x) {
+  torch_acos(x)
+}
+
+#' @export
+asin.torch_tensor <- function(x) {
+  torch_asin(x)
+}
+
+#' @export
+atan.torch_tensor <- function(x) {
+  torch_atan(x)
+}
+
+#' @export
+exp.torch_tensor <- function(x) {
+  torch_exp(x)
+}
+
+#' @export
+expm1.torch_tensor <- function(x) {
+  torch_expm1(x)
+}
+
+#' @export
+cos.torch_tensor <- function(x) {
+  torch_cos(x)
+}
+
+#' @export
+cosh.torch_tensor <- function(x) {
+  torch_cosh(x)
+}
+
+#' @export
+sin.torch_tensor <- function(x) {
+  torch_sin(x)
+}
+
+#' @export
+sinh.torch_tensor <- function(x) {
+  torch_sinh(x)
+}
+
+#' @export
+tan.torch_tensor <- function(x) {
+  torch_tan(x)
+}
+
+#' @export
+tanh.torch_tensor <- function(x) {
+  torch_tanh(x)
+}
+
+# helper function to replace nan in tensors
+replace_nan <- function(tensor, value) {
+  torch_where(torch_isnan(tensor),
+              torch_full_like(tensor, value),
+              tensor)
+}
+
+#' @export
+max.torch_tensor <- function(..., na.rm = FALSE) {
+  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, -Inf)) else list(...) 
+  l_max <- lapply(l, torch_max)
+  Reduce(function(x, y) torch_max(x, other = y), l_max)
+}
+
+#' @export
+min.torch_tensor <- function(..., na.rm = FALSE) {
+  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, Inf)) else list(...) 
+  l_min <- lapply(l, torch_min)
+  Reduce(function(x, y) torch_min(x, other = y), l_min)
+}
+
+#' @export
+prod.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
+  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, 1)) else list(...) 
+  if (length(l) == 1) {
+    if (!missing(dim)) {
+      return(torch_prod(l[[1]], dim = dim, keepdim = keepdim))
+    } else {
+      return(torch_prod(l[[1]]))
+    }
+  } else {
+    stopifnot(missing(dim))
+    return(Reduce(`*`, lapply(l, torch_prod)))
+  }
+}
+
+#' @export
+sum.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
+  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, 0)) else list(...) 
+  if (length(l) == 1) {
+    if (!missing(dim)) {
+      return(torch_sum(l[[1]], dim = dim, keepdim = keepdim))
+    } else {
+      return(torch_sum(l[[1]]))
+    }
+  } else {
+    stopifnot(missing(dim))
+    return(Reduce(`+`, lapply(l, torch_sum)))
+  }
+}

--- a/R/operators.R
+++ b/R/operators.R
@@ -8,8 +8,10 @@
 
 #' @export
 `-.torch_tensor` <- function(e1, e2) {
-  if (missing(e2))
-    e2 <- torch_zeros_like(e1)
+  if (missing(e2)) {
+    e2 <- e1
+    e1 <- torch_zeros_like(e1)
+  }
   
   torch_sub(e1, e2)
 }

--- a/R/operators.R
+++ b/R/operators.R
@@ -228,30 +228,26 @@ tanh.torch_tensor <- function(x) {
   torch_tanh(x)
 }
 
-# helper function to replace nan in tensors
-replace_nan <- function(tensor, value) {
-  torch_where(torch_isnan(tensor),
-              torch_full_like(tensor, value),
-              tensor)
-}
-
 #' @export
 max.torch_tensor <- function(..., na.rm = FALSE) {
-  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, -Inf)) else list(...) 
+  if (na.rm) stop('torch Tensors do not have NAs ')
+  l <- list(...) 
   l_max <- lapply(l, torch_max)
   Reduce(function(x, y) torch_max(x, other = y), l_max)
 }
 
 #' @export
 min.torch_tensor <- function(..., na.rm = FALSE) {
-  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, Inf)) else list(...) 
+  if (na.rm) stop('torch Tensors do not have NAs ')
+  l <- list(...)
   l_min <- lapply(l, torch_min)
   Reduce(function(x, y) torch_min(x, other = y), l_min)
 }
 
 #' @export
 prod.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
-  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, 1)) else list(...) 
+  if (na.rm) stop('torch Tensors do not have NAs ')
+  l <- list(...)
   if (length(l) == 1) {
     if (!missing(dim)) {
       return(torch_prod(l[[1]], dim = dim, keepdim = keepdim))
@@ -266,7 +262,8 @@ prod.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
 
 #' @export
 sum.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
-  l <- if (na.rm) lapply(list(...), function(tensor) replace_nan(tensor, 0)) else list(...) 
+  if (na.rm) stop('torch Tensors do not have NAs ')
+  l <- list(...)
   if (length(l) == 1) {
     if (!missing(dim)) {
       return(torch_sum(l[[1]], dim = dim, keepdim = keepdim))

--- a/R/operators.R
+++ b/R/operators.R
@@ -230,7 +230,7 @@ tanh.torch_tensor <- function(x) {
 
 #' @export
 max.torch_tensor <- function(..., na.rm = FALSE) {
-  if (na.rm) stop('torch Tensors do not have NAs ')
+  if (na.rm) stop('Torch tensors do not have NAs!')
   l <- list(...) 
   l_max <- lapply(l, torch_max)
   Reduce(function(x, y) torch_max(x, other = y), l_max)
@@ -238,7 +238,7 @@ max.torch_tensor <- function(..., na.rm = FALSE) {
 
 #' @export
 min.torch_tensor <- function(..., na.rm = FALSE) {
-  if (na.rm) stop('torch Tensors do not have NAs ')
+  if (na.rm) stop('Torch tensors do not have NAs!')
   l <- list(...)
   l_min <- lapply(l, torch_min)
   Reduce(function(x, y) torch_min(x, other = y), l_min)
@@ -246,7 +246,7 @@ min.torch_tensor <- function(..., na.rm = FALSE) {
 
 #' @export
 prod.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
-  if (na.rm) stop('torch Tensors do not have NAs ')
+  if (na.rm) stop('Torch tensors do not have NAs!')
   l <- list(...)
   if (length(l) == 1) {
     if (!missing(dim)) {
@@ -262,7 +262,7 @@ prod.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
 
 #' @export
 sum.torch_tensor <- function(..., dim, keepdim = FALSE, na.rm = FALSE) {
-  if (na.rm) stop('torch Tensors do not have NAs ')
+  if (na.rm) stop('Torch tensors do not have NAs!')
   l <- list(...)
   if (length(l) == 1) {
     if (!missing(dim)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,7 +31,7 @@ installed.
 
 ## Example
 
-Currently this package is only a prrof of concept and you can only create a Torch 
+Currently this package is only a proof of concept and you can only create a Torch 
 Tensor from an R object. And then convert back from a torch Tensor to an R object.
 
 ```{r}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ At the first package load additional software will be installed.
 
 ## Example
 
-Currently this package is only a prrof of concept and you can only
+Currently this package is only a proof of concept and you can only
 create a Torch Tensor from an R object. And then convert back from a
 torch Tensor to an R object.
 

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -35,6 +35,20 @@ test_that("^ works", {
   expect_equal_to_r(2 ^ x, 2 ^ c(1,2,3,4))
 })
 
+test_that("%% works", {
+  x <- torch_tensor(c(1,2,3,4))
+  expect_equal_to_r(x %% x, c(1,2,3,4) %% c(1,2,3,4))
+  expect_equal_to_r(x %% 2, c(1,2,3,4) %% 2)
+  expect_equal_to_r(2 %% x, 2 %% c(1,2,3,4))
+})
+
+test_that("%/% works", {
+  x <- torch_tensor(c(1,2,3,4))
+  expect_equal_to_r(x %/% x, c(1,2,3,4) %/% c(1,2,3,4))
+  expect_equal_to_r(x %/% 2, c(1,2,3,4) %/% 2)
+  expect_equal_to_r(2 %/% x, 2 %/% c(1,2,3,4))
+})
+
 test_that("> works", {
   x <- torch_tensor(c(2,2))
   y <- torch_tensor(c(2,3))
@@ -85,6 +99,27 @@ test_that("!= works", {
   expect_equal_to_r(x != 2, c(TRUE, FALSE))
 })
 
+test_that("& works", {
+  x <- torch_tensor(c(1,2))
+  y <- torch_tensor(c(2,2))
+  expect_equal_to_r(x & y, c(TRUE, TRUE))
+  expect_equal_to_r(x & 0, c(FALSE, FALSE))
+})
+
+test_that("| works", {
+  x <- torch_tensor(c(0,2))
+  y <- torch_tensor(c(1,2))
+  expect_equal_to_r(x | y, c(TRUE, TRUE))
+  expect_equal_to_r(x | 0, c(FALSE, TRUE))
+})
+
+test_that("! works", {
+  x <- torch_tensor(c(1,2))
+  y <- torch_tensor(c(0,2))
+  expect_equal_to_r(!x, c(FALSE, FALSE))
+  expect_equal_to_r(!y, c(TRUE, FALSE))
+})
+
 test_that("dim works", {
   x <- torch_randn(c(2,2))
   expect_equal(dim(x), c(2,2))
@@ -104,3 +139,91 @@ test_that("as.*", {
   expect_equal(as.double(t), as.double(x), tolerance = 1e-7)
   expect_equal(as.logical(t > 0.5), as.logical(x > 0.5))
 })
+
+test_that("abs works", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(abs(torch_tensor(x))), as.numeric(abs(x)), tolerance = 1e-7)
+})
+
+test_that("sign works", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(sign(torch_tensor(x))), as.numeric(sign(x)), tolerance = 1e-7)
+})
+
+test_that("sqrt works", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(sqrt(torch_tensor(x))), as.numeric(sqrt(x)), tolerance = 1e-7)
+})
+
+test_that("ceiling, floor, trunc work", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(ceiling(torch_tensor(x))), as.numeric(ceiling(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(floor(torch_tensor(x))), as.numeric(floor(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(trunc(torch_tensor(x))), as.numeric(trunc(x)), tolerance = 1e-7)
+})
+
+test_that("cumsum works", {
+  x <- runif(200)
+  expect_equal(as.numeric(cumsum(torch_tensor(x))), as.numeric(cumsum(x)), tolerance = 1e-7)
+})
+
+test_that("log* work", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(log(torch_tensor(x))), as.numeric(log(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(log(torch_tensor(x), base = 3)), as.numeric(log(x, base = 3)), tolerance = 1e-7)
+  expect_equal(as.numeric(log2(torch_tensor(x))), as.numeric(log2(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(log10(torch_tensor(x))), as.numeric(log10(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(log1p(torch_tensor(x))), as.numeric(log1p(x)), tolerance = 1e-7)
+})
+
+test_that("acos, asin, atan, cos*, sin*, tan* work", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(acos(torch_tensor(x))), as.numeric(acos(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(asin(torch_tensor(x))), as.numeric(asin(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(atan(torch_tensor(x))), as.numeric(atan(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(cos(torch_tensor(x))), as.numeric(cos(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(cosh(torch_tensor(x))), as.numeric(cosh(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(sin(torch_tensor(x))), as.numeric(sin(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(sinh(torch_tensor(x))), as.numeric(sinh(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(tan(torch_tensor(x))), as.numeric(tan(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(tanh(torch_tensor(x))), as.numeric(tanh(x)), tolerance = 1e-7)
+})
+
+test_that("exp* work", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  expect_equal(as.numeric(exp(torch_tensor(x))), as.numeric(exp(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(expm1(torch_tensor(x))), as.numeric(expm1(x)), tolerance = 1e-7)
+})
+
+test_that("max min work", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  y <- c(1, 2, 3)
+  z <- c(2, 3, NA)
+  expect_equal(as.numeric(max(torch_tensor(x))), max(x), tolerance = 1e-7)
+  expect_equal(as.numeric(max(torch_tensor(x), torch_tensor(y))), max(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(max(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), max(x, z, na.rm = TRUE), tolerance = 1e-7)
+  expect_equal(as.numeric(min(torch_tensor(x))), min(x), tolerance = 1e-7)
+  expect_equal(as.numeric(min(torch_tensor(x), torch_tensor(y))), min(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(min(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), min(x, z, na.rm = TRUE), tolerance = 1e-7)
+})
+
+test_that("prod works", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  y <- c(1, 2, 3)
+  z <- c(2, 3, NA)
+  expect_equal(as.numeric(prod(torch_tensor(x))), prod(x))
+  expect_equal(as.numeric(prod(torch_tensor(x), dim = 0)), as.numeric(torch_prod(x, dim = 0)), tolerance = 1e-7)
+  expect_equal(as.numeric(prod(torch_tensor(x), torch_tensor(y))), prod(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(prod(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), prod(x, z, na.rm = TRUE), tolerance = 1e-7)
+})
+
+test_that("sum works", {
+  x <- array(runif(200), dim = c(10, 5, 2))
+  y <- c(1, 2, 3)
+  z <- c(2, 3, NA)
+  expect_equal(as.numeric(sum(torch_tensor(x))), sum(x), tolerance = 1e-7)
+  expect_equal(as.numeric(sum(torch_tensor(x), dim = 0)), as.numeric(torch_sum(x, dim = 0)), tolerance = 1e-7)
+  expect_equal(as.numeric(sum(torch_tensor(x), torch_tensor(y))), sum(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(sum(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), sum(x, z, na.rm = TRUE), tolerance = 1e-7)
+})
+

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -198,32 +198,25 @@ test_that("exp* work", {
 test_that("max min work", {
   x <- array(runif(200), dim = c(10, 5, 2))
   y <- c(1, 2, 3)
-  z <- c(2, 3, NA)
   expect_equal(as.numeric(max(torch_tensor(x))), max(x), tolerance = 1e-7)
   expect_equal(as.numeric(max(torch_tensor(x), torch_tensor(y))), max(x, y), tolerance = 1e-7)
-  expect_equal(as.numeric(max(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), max(x, z, na.rm = TRUE), tolerance = 1e-7)
   expect_equal(as.numeric(min(torch_tensor(x))), min(x), tolerance = 1e-7)
   expect_equal(as.numeric(min(torch_tensor(x), torch_tensor(y))), min(x, y), tolerance = 1e-7)
-  expect_equal(as.numeric(min(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), min(x, z, na.rm = TRUE), tolerance = 1e-7)
 })
 
 test_that("prod works", {
   x <- array(runif(200), dim = c(10, 5, 2))
   y <- c(1, 2, 3)
-  z <- c(2, 3, NA)
   expect_equal(as.numeric(prod(torch_tensor(x))), prod(x))
   expect_equal(as.numeric(prod(torch_tensor(x), dim = 0)), as.numeric(torch_prod(x, dim = 0)), tolerance = 1e-7)
   expect_equal(as.numeric(prod(torch_tensor(x), torch_tensor(y))), prod(x, y), tolerance = 1e-7)
-  expect_equal(as.numeric(prod(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), prod(x, z, na.rm = TRUE), tolerance = 1e-7)
 })
 
 test_that("sum works", {
   x <- array(runif(200), dim = c(10, 5, 2))
   y <- c(1, 2, 3)
-  z <- c(2, 3, NA)
   expect_equal(as.numeric(sum(torch_tensor(x))), sum(x), tolerance = 1e-7)
   expect_equal(as.numeric(sum(torch_tensor(x), dim = 0)), as.numeric(torch_sum(x, dim = 0)), tolerance = 1e-7)
   expect_equal(as.numeric(sum(torch_tensor(x), torch_tensor(y))), sum(x, y), tolerance = 1e-7)
-  expect_equal(as.numeric(sum(torch_tensor(x), torch_tensor(z), na.rm = TRUE)), sum(x, z, na.rm = TRUE), tolerance = 1e-7)
 })
 

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -134,89 +134,89 @@ test_that("as.*", {
   x <- array(runif(200), dim = c(10, 5, 2))
   t <- torch_tensor(x)
   
-  expect_equal(as.numeric(t), as.numeric(x), tolerance = 1e-7)
+  expect_equal(as.numeric(t), as.numeric(x), tolerance = 1e-5)
   expect_equal(as.integer(t), as.integer(x))
-  expect_equal(as.double(t), as.double(x), tolerance = 1e-7)
+  expect_equal(as.double(t), as.double(x), tolerance = 1e-5)
   expect_equal(as.logical(t > 0.5), as.logical(x > 0.5))
 })
 
 test_that("abs works", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(abs(torch_tensor(x))), as.numeric(abs(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(abs(torch_tensor(x))), as.numeric(abs(x)), tolerance = 1e-5)
 })
 
 test_that("sign works", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(sign(torch_tensor(x))), as.numeric(sign(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(sign(torch_tensor(x))), as.numeric(sign(x)), tolerance = 1e-5)
 })
 
 test_that("sqrt works", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(sqrt(torch_tensor(x))), as.numeric(sqrt(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(sqrt(torch_tensor(x))), as.numeric(sqrt(x)), tolerance = 1e-5)
 })
 
 test_that("ceiling, floor, trunc work", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(ceiling(torch_tensor(x))), as.numeric(ceiling(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(floor(torch_tensor(x))), as.numeric(floor(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(trunc(torch_tensor(x))), as.numeric(trunc(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(ceiling(torch_tensor(x))), as.numeric(ceiling(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(floor(torch_tensor(x))), as.numeric(floor(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(trunc(torch_tensor(x))), as.numeric(trunc(x)), tolerance = 1e-5)
 })
 
 test_that("cumsum works", {
   x <- runif(200)
-  expect_equal(as.numeric(cumsum(torch_tensor(x))), as.numeric(cumsum(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(cumsum(torch_tensor(x))), as.numeric(cumsum(x)), tolerance = 1e-5)
 })
 
 test_that("log* work", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(log(torch_tensor(x))), as.numeric(log(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(log(torch_tensor(x), base = 3)), as.numeric(log(x, base = 3)), tolerance = 1e-7)
-  expect_equal(as.numeric(log2(torch_tensor(x))), as.numeric(log2(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(log10(torch_tensor(x))), as.numeric(log10(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(log1p(torch_tensor(x))), as.numeric(log1p(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(log(torch_tensor(x))), as.numeric(log(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(log(torch_tensor(x), base = 3)), as.numeric(log(x, base = 3)), tolerance = 1e-5)
+  expect_equal(as.numeric(log2(torch_tensor(x))), as.numeric(log2(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(log10(torch_tensor(x))), as.numeric(log10(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(log1p(torch_tensor(x))), as.numeric(log1p(x)), tolerance = 1e-5)
 })
 
 test_that("acos, asin, atan, cos*, sin*, tan* work", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(acos(torch_tensor(x))), as.numeric(acos(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(asin(torch_tensor(x))), as.numeric(asin(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(atan(torch_tensor(x))), as.numeric(atan(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(cos(torch_tensor(x))), as.numeric(cos(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(cosh(torch_tensor(x))), as.numeric(cosh(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(sin(torch_tensor(x))), as.numeric(sin(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(sinh(torch_tensor(x))), as.numeric(sinh(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(tan(torch_tensor(x))), as.numeric(tan(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(tanh(torch_tensor(x))), as.numeric(tanh(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(acos(torch_tensor(x))), as.numeric(acos(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(asin(torch_tensor(x))), as.numeric(asin(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(atan(torch_tensor(x))), as.numeric(atan(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(cos(torch_tensor(x))), as.numeric(cos(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(cosh(torch_tensor(x))), as.numeric(cosh(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(sin(torch_tensor(x))), as.numeric(sin(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(sinh(torch_tensor(x))), as.numeric(sinh(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(tan(torch_tensor(x))), as.numeric(tan(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(tanh(torch_tensor(x))), as.numeric(tanh(x)), tolerance = 1e-5)
 })
 
 test_that("exp* work", {
   x <- array(runif(200), dim = c(10, 5, 2))
-  expect_equal(as.numeric(exp(torch_tensor(x))), as.numeric(exp(x)), tolerance = 1e-7)
-  expect_equal(as.numeric(expm1(torch_tensor(x))), as.numeric(expm1(x)), tolerance = 1e-7)
+  expect_equal(as.numeric(exp(torch_tensor(x))), as.numeric(exp(x)), tolerance = 1e-5)
+  expect_equal(as.numeric(expm1(torch_tensor(x))), as.numeric(expm1(x)), tolerance = 1e-5)
 })
 
 test_that("max min work", {
   x <- array(runif(200), dim = c(10, 5, 2))
   y <- c(1, 2, 3)
-  expect_equal(as.numeric(max(torch_tensor(x))), max(x), tolerance = 1e-7)
-  expect_equal(as.numeric(max(torch_tensor(x), torch_tensor(y))), max(x, y), tolerance = 1e-7)
-  expect_equal(as.numeric(min(torch_tensor(x))), min(x), tolerance = 1e-7)
-  expect_equal(as.numeric(min(torch_tensor(x), torch_tensor(y))), min(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(max(torch_tensor(x))), max(x), tolerance = 1e-5)
+  expect_equal(as.numeric(max(torch_tensor(x), torch_tensor(y))), max(x, y), tolerance = 1e-5)
+  expect_equal(as.numeric(min(torch_tensor(x))), min(x), tolerance = 1e-5)
+  expect_equal(as.numeric(min(torch_tensor(x), torch_tensor(y))), min(x, y), tolerance = 1e-5)
 })
 
 test_that("prod works", {
   x <- array(runif(200), dim = c(10, 5, 2))
   y <- c(1, 2, 3)
   expect_equal(as.numeric(prod(torch_tensor(x))), prod(x))
-  expect_equal(as.numeric(prod(torch_tensor(x), dim = 0)), as.numeric(torch_prod(x, dim = 0)), tolerance = 1e-7)
-  expect_equal(as.numeric(prod(torch_tensor(x), torch_tensor(y))), prod(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(prod(torch_tensor(x), dim = 0)), as.numeric(torch_prod(x, dim = 0)), tolerance = 1e-5)
+  expect_equal(as.numeric(prod(torch_tensor(x), torch_tensor(y))), prod(x, y), tolerance = 1e-5)
 })
 
 test_that("sum works", {
   x <- array(runif(200), dim = c(10, 5, 2))
   y <- c(1, 2, 3)
-  expect_equal(as.numeric(sum(torch_tensor(x))), sum(x), tolerance = 1e-7)
-  expect_equal(as.numeric(sum(torch_tensor(x), dim = 0)), as.numeric(torch_sum(x, dim = 0)), tolerance = 1e-7)
-  expect_equal(as.numeric(sum(torch_tensor(x), torch_tensor(y))), sum(x, y), tolerance = 1e-7)
+  expect_equal(as.numeric(sum(torch_tensor(x))), sum(x), tolerance = 1e-5)
+  expect_equal(as.numeric(sum(torch_tensor(x), dim = 0)), as.numeric(torch_sum(x, dim = 0)), tolerance = 1e-5)
+  expect_equal(as.numeric(sum(torch_tensor(x), torch_tensor(y))), sum(x, y), tolerance = 1e-5)
 })
 

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -12,6 +12,7 @@ test_that("- works", {
   expect_equal_to_r(x - x, rep(0, 4))
   expect_equal_to_r(x - 2, c(1,2,3,4) - 2)
   expect_equal_to_r(2 - x, 2 - c(1,2,3,4))
+  expect_equal_to_r(-x, - c(1,2,3,4))
 })
 
 test_that("* works", {


### PR DESCRIPTION
This pull request implements the following R generic functions along with the corresponding test cases:
> %%, %/%, &, |, !, abs, sign, sqrt, ceiling, floor, trunc, cumsum, log, log10, log2, log1p, exp, expm1, cos, cosh, sin, sinh, tan, tanh, acos, asin, atan, max, min, prod, sum

While most functions are straightforward to implement, several special cases are noted here:

- `log`: default R has a `base` argument but I didn't find the corresponding in pytorch, so I did a trick as`torch_log(x)/torch_log(base)`
- `sum` and `prod`: `nan`s in the tensor will be ignored if `na.rm=T`. If single tensor is given, one can specify `dim` and `keepdim`. If multiple tensors are given, `dim` argument is not allowed and only a single value will be computed from them.
- `min` and `max`: `nan`s in the tensor will be ignored if `na.rm=T`. Only a single value is returned.