### PR TITLE
Allows opting in to build lantern by labeling the PR with `lantern`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Build lantern and get libtorch
-        if: matrix.install == 0
+        if: matrix.install == 0 || contains( github.event.pull_request.labels.*.name, 'lantern')
         run: | 
           Rscript tools/buildlantern.R
       - name: Check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+
 name: Test
 
 jobs:


### PR DESCRIPTION
By labelling a PR with the `lantern` label it will build lantern on the CI instead of installing the pre-build binaries.
This is useful for testing PR's that changes lantern code.

The GPU build is not affected and will still use the pre-built binaries.