### PR TITLE
Support logging to file and minor lantern fixes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       INSTALL_TORCH: ${{ matrix.install }}
       CRAN: ${{ matrix.cran }}
+      TORCH_LOG: 2
 
     steps:
       - uses: actions/checkout@v1
@@ -63,6 +64,9 @@ jobs:
           setwd("tests")
           source("testthat.R")
         shell: Rscript {0}
+      - name: Logs
+        if: ${{ failure() }}
+        run: cat lantern.log
   gpu:
     runs-on: self-hosted
     env:

--- a/R/lantern_load.R
+++ b/R/lantern_load.R
@@ -14,7 +14,7 @@ lantern_start <- function(version = lantern_default(), reload = FALSE) {
   
   cpp_lantern_init(normalizePath(install_path()))
   
-  log_enabled <- Sys.getenv("TORCH_LOG", "0") == "1"
+  log_enabled <- as.integer(Sys.getenv("TORCH_LOG", "0"))
   cpp_lantern_configure(log_enabled)
   
   .globals$lantern_started <- TRUE

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -39,7 +39,16 @@
 #include <stdio.h>
 
 extern bool lanternLogEnabled;
-#define LLOG(...) if (lanternLogEnabled) { printf("%ld INFO ", time(NULL)) ; printf(__VA_ARGS__); printf("\n"); }
+#define LLOG(...) if (lanternLogEnabled) {                         \
+  printf("%ld INFO ", time(NULL));                                 \
+  printf(__VA_ARGS__);                                             \
+  printf("\n");                                                    \
+  FILE *pFile = fopen("lantern.log", "a");                         \
+  fprintf(pFile, "%ld INFO ", time(NULL));                         \
+  fprintf(pFile, __VA_ARGS__);                                     \
+  fprintf(pFile, "\n");                                            \
+  fclose(pFile);                                                   \
+}
 
 #ifdef LANTERN_BUILD
 extern std::string *pLanternLastError;

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -38,11 +38,13 @@
 #include <stdint.h>
 #include <stdio.h>
 
-extern bool lanternLogEnabled;
-#define LLOG(...) if (lanternLogEnabled) {                         \
+extern int lanternLogEnabled;
+#define LLOG(...) if ((lanternLogEnabled & 1) == 1) {              \
   printf("%ld INFO ", time(NULL));                                 \
   printf(__VA_ARGS__);                                             \
   printf("\n");                                                    \
+}                                                                  \
+if ((lanternLogEnabled & 2) == 2) {                                \
   FILE *pFile = fopen("lantern.log", "a");                         \
   fprintf(pFile, "%ld INFO ", time(NULL));                         \
   fprintf(pFile, __VA_ARGS__);                                     \
@@ -88,7 +90,7 @@ extern "C"
 {
 #endif
 
-  LANTERN_API void(LANTERN_PTR lanternConfigure)(bool log);
+  LANTERN_API void(LANTERN_PTR lanternConfigure)(int log);
   LANTERN_API const char*(LANTERN_PTR lanternVersion)();
   LANTERN_API void(LANTERN_PTR lanternSetLastError)(const char*);
   LANTERN_API void(LANTERN_PTR lanternLastErrorClear)();

--- a/lantern/src/Autograd.cpp
+++ b/lantern/src/Autograd.cpp
@@ -47,7 +47,7 @@ unsigned int _lantern_Tensor_register_hook(void *self, void *hook)
     auto h = reinterpret_cast<LanternObject<std::function<torch::Tensor(torch::Tensor)>> *>(hook)->get();
     auto x = reinterpret_cast<LanternObject<torch::Tensor> *>(self)->get();
     return x.register_hook(h);
-    LANTERN_FUNCTION_END_VOID
+    LANTERN_FUNCTION_END_RET(0)
 }
 
 // Creating the hook in the right format to be passed to .register_hook
@@ -99,7 +99,7 @@ void *_lantern_variable_list_get(void *self, int64_t i)
     auto s = reinterpret_cast<LanternObject<torch::autograd::variable_list> *>(self)->get();
     torch::Tensor out = s[i];
     return (void *)new LanternObject<torch::Tensor>(out);
-    LANTERN_FUNCTION_END_VOID
+    LANTERN_FUNCTION_END
 }
 
 int64_t _lantern_variable_list_size(void *self)

--- a/lantern/src/lantern.cpp
+++ b/lantern/src/lantern.cpp
@@ -8,8 +8,8 @@
 
 #include "utils.hpp"
 
-bool lanternLogEnabled = false;
-void lanternConfigure(bool log)
+int lanternLogEnabled = 0;
+void lanternConfigure(int log)
 {
   lanternLogEnabled = log;
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23101,11 +23101,11 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_lantern_configure
-void cpp_lantern_configure(bool log);
+void cpp_lantern_configure(int log);
 RcppExport SEXP _torch_cpp_lantern_configure(SEXP logSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< bool >::type log(logSEXP);
+    Rcpp::traits::input_parameter< int >::type log(logSEXP);
     cpp_lantern_configure(log);
     return R_NilValue;
 END_RCPP

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -268,7 +268,7 @@ Rcpp::XPtr<XPtrTorch> cpp_Function_lambda (Rcpp::Function f)
     }
     
     return result.get();
-    LANTERN_CALLBACK_END("Unknown error in lambda function.", lantern_variable_list_new())
+    LANTERN_CALLBACK_END("Unknown error in lambda function.", _lantern_variable_list_new())
   });
   
   XPtrTorch out = lantern_Function_lambda(&rcpp_call_forward, fun);

--- a/src/lantern.cpp
+++ b/src/lantern.cpp
@@ -12,7 +12,7 @@ void lantern_host_handler()
 }
 
 // [[Rcpp::export]]
-void cpp_lantern_configure(bool log) {
+void cpp_lantern_configure(int log) {
   lanternConfigure(log);
 }
 

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -38,8 +38,19 @@
 #include <stdint.h>
 #include <stdio.h>
 
-extern bool lanternLogEnabled;
-#define LLOG(...) if (lanternLogEnabled) { printf("%ld INFO ", time(NULL)) ; printf(__VA_ARGS__); printf("\n"); }
+extern int lanternLogEnabled;
+#define LLOG(...) if ((lanternLogEnabled & 1) == 1) {              \
+  printf("%ld INFO ", time(NULL));                                 \
+  printf(__VA_ARGS__);                                             \
+  printf("\n");                                                    \
+}                                                                  \
+if ((lanternLogEnabled & 2) == 2) {                                \
+  FILE *pFile = fopen("lantern.log", "a");                         \
+  fprintf(pFile, "%ld INFO ", time(NULL));                         \
+  fprintf(pFile, __VA_ARGS__);                                     \
+  fprintf(pFile, "\n");                                            \
+  fclose(pFile);                                                   \
+}
 
 #ifdef LANTERN_BUILD
 extern std::string *pLanternLastError;
@@ -79,7 +90,7 @@ extern "C"
 {
 #endif
 
-  LANTERN_API void(LANTERN_PTR lanternConfigure)(bool log);
+  LANTERN_API void(LANTERN_PTR lanternConfigure)(int log);
   LANTERN_API const char*(LANTERN_PTR lanternVersion)();
   LANTERN_API void(LANTERN_PTR lanternSetLastError)(const char*);
   LANTERN_API void(LANTERN_PTR lanternLastErrorClear)();


### PR DESCRIPTION
We can now set `Sys.setenv(TORCH_LOG = 1)` to log lantern calls and errors to console, `Sys.setenv(TORCH_LOG = 2)` to log to `lantern.log` and ``Sys.setenv(TORCH_LOG = 3)` to log to both.

Also couple `LANTERN_FUNCTION_END` fixes and printing the logs in the GitHub tests when a test fails.

Logs look like:

```
1594316118 INFO Entering _lantern_Generator
1594316118 INFO Entering _lantern_Generator_set_current_seed
1594316121 INFO Entering _lantern_Layout_strided
1594316121 INFO Entering _lantern_TensorOptions
1594316121 INFO Entering _lantern_TensorOptions_layout
1594316121 INFO Entering _lantern_TensorOptions_delete
1594316121 INFO Entering _lantern_TensorOptions_requires_grad
1594316121 INFO Entering _lantern_TensorOptions_delete
1594316121 INFO Entering _lantern_vector_int64_t
1594316121 INFO Entering _lantern_rand_intarrayref_tensoroptions
1594316121 INFO Entering _lantern_Tensor_StreamInsertion
1594316129 INFO Entering _lantern_Layout_strided
1594316129 INFO Entering _lantern_TensorOptions
1594316129 INFO Entering _lantern_TensorOptions_layout
1594316129 INFO Entering _lantern_TensorOptions_delete
1594316129 INFO Entering _lantern_TensorOptions_requires_grad
1594316129 INFO Entering _lantern_TensorOptions_delete
1594316129 INFO Entering _lantern_vector_int64_t
1594316129 INFO Entering _lantern_rand_intarrayref_tensoroptions
1594316129 INFO Entering _lantern_Layout_strided
1594316129 INFO Entering _lantern_TensorOptions
1594316129 INFO Entering _lantern_TensorOptions_layout
1594316129 INFO Entering _lantern_TensorOptions_delete
1594316129 INFO Entering _lantern_TensorOptions_requires_grad
1594316129 INFO Entering _lantern_TensorOptions_delete
1594316129 INFO Entering _lantern_vector_int64_t
1594316129 INFO Entering _lantern_rand_intarrayref_tensoroptions
1594316129 INFO Entering _lantern_mul_tensor_tensor
1594316129 INFO Error The size of tensor a (3) must match the size of tensor b (4) at non-singleton dimension 0 (infer_size at ../aten/src/ATen/ExpandUtils.cpp:24)
frame #0: c10::Error::Error(c10::SourceLocation, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 135 (0x1122ccf47 in libc10.dylib)
frame #1: at::infer_size(c10::ArrayRef<long long>, c10::ArrayRef<long long>) + 772 (0x11e676f14 in libtorch_cpu.dylib)
frame #2: at::TensorIterator::compute_shape() + 342 (0x11eaa36a6 in libtorch_cpu.dylib)
frame #3: at::TensorIterator::build() + 682 (0x11eaa184a in libtorch_cpu.dylib)
frame #4: at::TensorIterator::binary_op(at::Tensor&, at::Tensor const&, at::Tensor const&, bool) + 414 (0x11eaa14fe in libtorch_cpu.dylib)
frame #5: at::native::mul(at::Tensor const&, at::Tensor const&) + 81 (0x11e794ad1 in libtorch_cpu.dylib)
frame #6: at::CPUType::mul_Tensor(at::Tensor const&, at::Tensor const&) + 109 (0x11ed2f18d in libtorch_cpu.dylib)
frame #7: c10::detail::wrap_kernel_functor_unboxed_<c10::detail::WrapRuntimeKernelFunctor_<at::Tensor (*)(at::Tensor const&, at::Tensor const&), at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, at::Tensor const&> >, at::Tensor (at::Tensor const&, at::Tensor const&)>::call(c10::OperatorKernel*, at::Tensor const&, at::Tensor const&) + 21 (0x11ed8c7e5 in libtorch_cpu.dylib)
frame #8: at::Tensor c10::OperatorHandle::callUnboxed<at::Tensor, at::Tensor const&, at::Tensor const&>(at::Tensor const&, at::Tensor const&) const + 271 (0x11e7a64af in libtorch_cpu.dylib)
frame #9: torch::autograd::VariableType::mul_Tensor(at::Tensor const&, at::Tensor const&) + 1633 (0x120fdf781 in libtorch_cpu.dylib)
frame #10: c10::detail::wrap_kernel_functor_unboxed_<c10::detail::WrapRuntimeKernelFunctor_<at::Tensor (*)(at::Tensor const&, at::Tensor const&), at::Tensor, c10::guts::typelist::typelist<at::Tensor const&, at::Tensor const&> >, at::Tensor (at::Tensor const&, at::Tensor const&)>::call(c10::OperatorKernel*, at::Tensor const&, at::Tensor const&) + 21 (0x11ed8c7e5 in libtorch_cpu.dylib)
frame #11: at::Tensor c10::KernelFunction::callUnboxed<at::Tensor, at::Tensor const&, at::Tensor const&>(c10::OperatorHandle const&, at::Tensor const&, at::Tensor const&) const + 165 (0x111c32025 in liblantern.dylib)
frame #12: at::Tensor c10::Dispatcher::callUnboxedWithDispatchKey<at::Tensor, at::Tensor const&, at::Tensor const&>(c10::OperatorHandle const&, c10::DispatchKey, at::Tensor const&, at::Tensor const&) const + 171 (0x111c31f6b in liblantern.dylib)
frame #13: at::Tensor c10::Dispatcher::callUnboxed<at::Tensor, at::Tensor const&, at::Tensor const&>(c10::OperatorHandle const&, at::Tensor const&, at::Tensor const&) const + 158 (0x111c31eae in liblantern.dylib)
frame #14: at::Tensor c10::OperatorHandle::callUnboxed<at::Tensor, at::Tensor const&, at::Tensor const&>(at::Tensor const&, at::Tensor const&) const + 94 (0x111c31dfe in liblantern.dylib)
frame #15: at::mul(at::Tensor const&, at::Tensor const&) + 154 (0x111943c3a in liblantern.dylib)
frame #16: _lantern_mul_tensor_tensor + 367 (0x1119433ff in liblantern.dylib)
frame #17: cpp_torch_namespace_mul_self_Tensor_other_Tensor(Rcpp::XPtr<XPtrTorchTensor, Rcpp::PreserveStorage, &(void Rcpp::standard_delete_finalizer<XPtrTorchTensor>(XPtrTorchTensor*)), false>, Rcpp::XPtr<XPtrTorchTensor, Rcpp::PreserveStorage, &(void Rcpp::standard_delete_finalizer<XPtrTorchTensor>(XPtrTorchTensor*)), false>) + 71 (0x11127b847 in torchpkg.so)
frame #18: _torch_cpp_torch_namespace_mul_self_Tensor_other_Tensor + 114 (0x111097f52 in torchpkg.so)
frame #19: R_doDotCall + 958 (0x10e7eaa0e in libR.dylib)
frame #20: do_dotcall + 323 (0x10e7ec8a3 in libR.dylib)
frame #21: bcEval + 19608 (0x10e820768 in libR.dylib)
frame #22: Rf_eval + 443 (0x10e81b39b in libR.dylib)
frame #23: R_execClosure + 3004 (0x10e82dd0c in libR.dylib)
frame #24: Rf_eval + 1772 (0x10e81b8cc in libR.dylib)
frame #25: do_docall + 591 (0x10e7b9ddf in libR.dylib)
frame #26: bcEval + 19608 (0x10e820768 in libR.dylib)
frame #27: Rf_eval + 443 (0x10e81b39b in libR.dylib)
frame #28: R_execClosure + 3004 (0x10e82dd0c in libR.dylib)
frame #29: bcEval + 18659 (0x10e8203b3 in libR.dylib)
frame #30: Rf_eval + 443 (0x10e81b39b in libR.dylib)
frame #31: R_execClosure + 3004 (0x10e82dd0c in libR.dylib)
frame #32: bcEval + 18659 (0x10e8203b3 in libR.dylib)
frame #33: Rf_eval + 443 (0x10e81b39b in libR.dylib)
frame #34: R_execClosure + 3004 (0x10e82dd0c in libR.dylib)
frame #35: bcEval + 18659 (0x10e8203b3 in libR.dylib)
frame #36: Rf_eval + 443 (0x10e81b39b in libR.dylib)
frame #37: R_execClosure + 3004 (0x10e82dd0c in libR.dylib)
frame #38: bcEval + 18659 (0x10e8203b3 in libR.dylib)
frame #39: Rf_eval + 443 (0x10e81b39b in libR.dylib)
frame #40: R_execClosure + 3004 (0x10e82dd0c in libR.dylib)
frame #41: Rf_DispatchGroup + 2160 (0x10e832d20 in libR.dylib)
frame #42: do_arith + 171 (0x10e77f47b in libR.dylib)
frame #43: Rf_eval + 1811 (0x10e81b8f3 in libR.dylib)
frame #44: Rf_ReplIteration + 794 (0x10e85ea2a in libR.dylib)
frame #45: run_Rmainloop + 207 (0x10e86000f in libR.dylib)
frame #46: main + 27 (0x10e764f5b in R)
frame #47: start + 1 (0x7fff6d396cc9 in libdyld.dylib)
 in _lantern_mul_tensor_tensor
```