### PR TITLE
Fix ordering for parallel make

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -3,3 +3,6 @@ all: $(SHLIB) rename
 rename:
 	@echo "Renaming torch lib to torchpkg"
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/renamelib.R"
+
+# in order to rename SHLIb must be done.
+rename : $(SHLIB)

--- a/tools/renamelib.R
+++ b/tools/renamelib.R
@@ -1,16 +1,5 @@
 libs_path <- getwd()
 
-# wait, because of it's built in parallel this script might run before
-# finishing.
-start <- Sys.time()
-timeout <- 15*60
-
-while(length(dir(libs_path, pattern = "torch\\.")) == 0) {
-  Sys.sleep(4)
-  if (as.numeric(Sys.time() - start) > timeout)
-    break 
-}
-
 for (lib in dir(libs_path, pattern = "torch\\.")) {
   file.copy(file.path(libs_path, lib),
             file.path(libs_path, gsub("torch", "torchpkg", lib)),


### PR DESCRIPTION
declare rename dependency on $(SHLIB) so it's always run in the correct order.