### PR TITLE
dedup duplicated parameters from the parameter list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
   returned when doing `state_dict()` on it. (#300)
 - Fixed bug related to random number seeds when using in-place methods. (#303)
 - Fixed `nn_batchnorm*` so it returns the same results as PyTorch (#302)
+- Fixed a bug that made `nn_module$parameter` when there were shared parameters
+  between layers. (#306)
 
 # torch 0.1.0
 

--- a/R/nn.R
+++ b/R/nn.R
@@ -218,7 +218,17 @@ nn_Module <- R6::R6Class(
     parameters = function() {
       pars <- lapply(private$modules_, function(x) x$parameters)
       pars <- append(pars, private$parameters_)
-      unlist(pars, recursive = TRUE, use.names = TRUE)
+      pars <- unlist(pars, recursive = TRUE, use.names = TRUE)
+      
+      # deduplicate the parameters based on the storage location
+      # see (#305)
+      # in python a `set` is used to do this. but there's no straightforward
+      # way to do this in R because the R objects could be possibly different
+      # and still point to the same parameter in memory.
+      addresses <- sapply(pars, function(x) x$storage()$data_ptr())
+      pars <- pars[!duplicated(addresses)]
+      
+      pars
     }
   )
 )

--- a/tests/testthat/test-nn.R
+++ b/tests/testthat/test-nn.R
@@ -360,3 +360,15 @@ test_that("nn_module_list names", {
   )
    
 })
+
+test_that("deduplicate duplicated parameters", {
+  m <- nn_module(
+    initialize = function(x) {
+      x <- nn_linear(10, 10)
+      self$x <- x
+      self$y <- x
+    }
+  )
+  expect_length(m()$parameters, 2)
+  expect_named(m()$parameters, c("x.weight", "x.bias"))
+})


### PR DESCRIPTION
Fix #305 