### PR TITLE
Fix crash with grad_fn

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,6 +81,10 @@ cpp_tensor_grad_fn <- function(self) {
     .Call('_torch_cpp_tensor_grad_fn', PACKAGE = 'torchpkg', self)
 }
 
+cpp_pointer_is_null <- function(x) {
+    .Call('_torch_cpp_pointer_is_null', PACKAGE = 'torchpkg', x)
+}
+
 cpp_autograd_node_name <- function(self) {
     .Call('_torch_cpp_autograd_node_name', PACKAGE = 'torchpkg', self)
 }

--- a/R/autograd.R
+++ b/R/autograd.R
@@ -431,7 +431,12 @@ Node <- R6::R6Class(
 )
 
 Tensor$set("active", "grad_fn", function() {
-  Node$new(cpp_tensor_grad_fn(self$ptr))
+  o <- cpp_tensor_grad_fn(self$ptr)
+  
+  if (cpp_pointer_is_null(o))
+    return(NULL)
+  
+  Node$new(o)
 })
 
 #' Computes the sum of gradients of given tensors w.r.t. graph leaves.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -233,6 +233,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_pointer_is_null
+bool cpp_pointer_is_null(Rcpp::XPtr<XPtrTorchTensor> x);
+RcppExport SEXP _torch_cpp_pointer_is_null(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_pointer_is_null(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_autograd_node_name
 std::string cpp_autograd_node_name(Rcpp::XPtr<XPtrTorch> self);
 RcppExport SEXP _torch_cpp_autograd_node_name(SEXP selfSEXP) {
@@ -23884,6 +23895,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_autograd_context_mark_dirty", (DL_FUNC) &_torch_cpp_autograd_context_mark_dirty, 2},
     {"_torch_cpp_autograd_context_mark_non_differentiable", (DL_FUNC) &_torch_cpp_autograd_context_mark_non_differentiable, 2},
     {"_torch_cpp_tensor_grad_fn", (DL_FUNC) &_torch_cpp_tensor_grad_fn, 1},
+    {"_torch_cpp_pointer_is_null", (DL_FUNC) &_torch_cpp_pointer_is_null, 1},
     {"_torch_cpp_autograd_node_name", (DL_FUNC) &_torch_cpp_autograd_node_name, 1},
     {"_torch_cpp_autograd_node_next_edges", (DL_FUNC) &_torch_cpp_autograd_node_next_edges, 1},
     {"_torch_cpp_autograd_edge_function", (DL_FUNC) &_torch_cpp_autograd_edge_function, 1},

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -434,6 +434,16 @@ Rcpp::XPtr<XPtrTorch> cpp_tensor_grad_fn (Rcpp::XPtr<XPtrTorchTensor> self)
 }
 
 // [[Rcpp::export]]
+bool cpp_pointer_is_null (Rcpp::XPtr<XPtrTorchTensor> x)
+{
+  if (x->get() == NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// [[Rcpp::export]]
 std::string cpp_autograd_node_name (Rcpp::XPtr<XPtrTorch> self)
 {
   return std::string(lantern_Node_name(self->get()));

--- a/tests/testthat/test-autograd.R
+++ b/tests/testthat/test-autograd.R
@@ -532,6 +532,9 @@ test_that("grad_fn works", {
   expect_length(k, 1)
   l <- k$next_functions
   expect_length(l, 0)
+  
+  x <- torch_tensor(1)
+  expect_true(is.null(x$grad_fn))
 })
 
 test_that("autograd_backward", {


### PR DESCRIPTION
grad_fn would be a NULL pointer when the tensors doesn't have a grad_fn and that would cause a crash when trying to get the name of this NULL pointer.

Fix #320 