### PR TITLE
Implement element_size

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -7105,6 +7105,10 @@ cpp_as_array <- function(x) {
     .Call('_torch_cpp_as_array', PACKAGE = 'torchpkg', x)
 }
 
+cpp_tensor_element_size <- function(x) {
+    .Call('_torch_cpp_tensor_element_size', PACKAGE = 'torchpkg', x)
+}
+
 cpp_tensor_dim <- function(x) {
     .Call('_torch_cpp_tensor_dim', PACKAGE = 'torchpkg', x)
 }

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -56,6 +56,9 @@ Tensor <- R7Class(
       
       x[dim]
     },
+    element_size = function() {
+      cpp_tensor_element_size(self$ptr)
+    },
     numel = function() {
       cpp_tensor_numel(self$ptr)
     },

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -173,6 +173,8 @@ extern "C"
   HOST_API bool * lantern_Tensor_data_ptr_bool(void *self) { bool * ret = _lantern_Tensor_data_ptr_bool(self); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_numel)(void *self);
   HOST_API int64_t lantern_Tensor_numel(void *self) { int64_t ret = _lantern_Tensor_numel(self); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_element_size)(void *self);
+  HOST_API int64_t lantern_Tensor_element_size(void *self) { int64_t ret = _lantern_Tensor_element_size(self); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_size)(void *self, int64_t i);
   HOST_API int64_t lantern_Tensor_size(void *self, int64_t i) { int64_t ret = _lantern_Tensor_size(self, i); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_ndimension)(void *self);
@@ -4143,6 +4145,7 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(_lantern_Tensor_data_ptr_int16_t);
   LOAD_SYMBOL(_lantern_Tensor_data_ptr_bool);
   LOAD_SYMBOL(_lantern_Tensor_numel);
+  LOAD_SYMBOL(_lantern_Tensor_element_size);
   LOAD_SYMBOL(_lantern_Tensor_ndimension);
   LOAD_SYMBOL(_lantern_Tensor_size);
   LOAD_SYMBOL(_lantern_Tensor_dtype);

--- a/lantern/src/Tensor.cpp
+++ b/lantern/src/Tensor.cpp
@@ -138,6 +138,14 @@ int64_t _lantern_Tensor_numel(void *self)
   LANTERN_FUNCTION_END_RET(0)
 }
 
+int64_t _lantern_Tensor_element_size(void *self)
+{
+  LANTERN_FUNCTION_START
+  torch::Tensor x = reinterpret_cast<LanternObject<torch::Tensor> *>(self)->get();
+  return x.element_size();
+  LANTERN_FUNCTION_END_RET(0)
+}
+
 int64_t _lantern_Tensor_ndimension(void *self)
 {
   LANTERN_FUNCTION_START

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23607,6 +23607,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_tensor_element_size
+int cpp_tensor_element_size(Rcpp::XPtr<XPtrTorchTensor> x);
+RcppExport SEXP _torch_cpp_tensor_element_size(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<XPtrTorchTensor> >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_tensor_element_size(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_tensor_dim
 std::vector<int> cpp_tensor_dim(Rcpp::XPtr<XPtrTorchTensor> x);
 RcppExport SEXP _torch_cpp_tensor_dim(SEXP xSEXP) {
@@ -25651,6 +25662,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_torch_tensor_dtype", (DL_FUNC) &_torch_cpp_torch_tensor_dtype, 1},
     {"_torch_cpp_torch_tensor", (DL_FUNC) &_torch_cpp_torch_tensor, 5},
     {"_torch_cpp_as_array", (DL_FUNC) &_torch_cpp_as_array, 1},
+    {"_torch_cpp_tensor_element_size", (DL_FUNC) &_torch_cpp_tensor_element_size, 1},
     {"_torch_cpp_tensor_dim", (DL_FUNC) &_torch_cpp_tensor_dim, 1},
     {"_torch_cpp_tensor_numel", (DL_FUNC) &_torch_cpp_tensor_numel, 1},
     {"_torch_cpp_tensor_device", (DL_FUNC) &_torch_cpp_tensor_device, 1},

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -173,6 +173,8 @@ extern "C"
   HOST_API bool * lantern_Tensor_data_ptr_bool(void *self) { bool * ret = _lantern_Tensor_data_ptr_bool(self); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_numel)(void *self);
   HOST_API int64_t lantern_Tensor_numel(void *self) { int64_t ret = _lantern_Tensor_numel(self); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_element_size)(void *self);
+  HOST_API int64_t lantern_Tensor_element_size(void *self) { int64_t ret = _lantern_Tensor_element_size(self); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_size)(void *self, int64_t i);
   HOST_API int64_t lantern_Tensor_size(void *self, int64_t i) { int64_t ret = _lantern_Tensor_size(self, i); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Tensor_ndimension)(void *self);
@@ -4143,6 +4145,7 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(_lantern_Tensor_data_ptr_int16_t);
   LOAD_SYMBOL(_lantern_Tensor_data_ptr_bool);
   LOAD_SYMBOL(_lantern_Tensor_numel);
+  LOAD_SYMBOL(_lantern_Tensor_element_size);
   LOAD_SYMBOL(_lantern_Tensor_ndimension);
   LOAD_SYMBOL(_lantern_Tensor_size);
   LOAD_SYMBOL(_lantern_Tensor_dtype);

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -209,6 +209,10 @@ Rcpp::List cpp_as_array (Rcpp::XPtr<XPtrTorchTensor> x) {
   Rcpp::stop("dtype not handled");
 };
 
+// [[Rcpp::export]]
+int cpp_tensor_element_size (Rcpp::XPtr<XPtrTorchTensor> x) {
+  return lantern_Tensor_element_size(x->get());
+}
 
 // [[Rcpp::export]]
 std::vector<int> cpp_tensor_dim (Rcpp::XPtr<XPtrTorchTensor> x) {

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -263,4 +263,37 @@ test_that("max and min", {
     class = "value_error"
   )
   
-}) 
+})
+
+test_that("element_size works", {
+  x <- torch_tensor(1, dtype = torch_int8())
+  result <- x$element_size()
+  expect_equal(result, 1L)
+  types <- list(
+    torch_float32(),
+    torch_float(),
+    torch_float64(),
+    torch_double(),
+    torch_float16(),
+    torch_half(),
+    torch_uint8(),
+    torch_int8(),
+    torch_int16(),
+    torch_short(),
+    torch_int32(),
+    torch_int(),
+    torch_int64(),
+    torch_long(),
+    torch_bool(),
+    torch_quint8(),
+    torch_qint8(),
+    torch_qint32()
+  )
+  for (type in types) {
+    x <- torch_tensor(1, dtype = type)
+    result <- x$element_size()
+    expect_true(is.integer(result))
+    expect_true(result > 0L)
+    expect_true(length(result) == 1)
+  }
+})

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -290,7 +290,14 @@ test_that("element_size works", {
     torch_qint32()
   )
   for (type in types) {
-    x <- torch_tensor(1, dtype = type)
+    
+    if (type == torch_quint8() || type == torch_qint8() || type == torch_qint32()) {
+      x <- torch_tensor(1, dtype = torch_float())
+      x <- torch_quantize_per_tensor(x, scale = 0.1, zero_point = 10, dtype = type)
+    } else {
+      x <- torch_tensor(1, dtype = type)  
+    }
+  
     result <- x$element_size()
     expect_true(is.integer(result))
     expect_true(result > 0L)


### PR DESCRIPTION
Hi @dfalbel . It still crashes on my machine, but I thought this small PR would be a good way to discuss what I am missing and to learn how to contribute efficiently.

```R
callr::r(function() { 
  library(torch)
  x <- torch_tensor(1)
  result <- x$element_size()
}) # crashes R session
```

Relates to #240 