### PR TITLE
Add tensor$bool

### DIFF
--- a/R/tensor.R
+++ b/R/tensor.R
@@ -82,6 +82,9 @@ Tensor <- R7Class(
       
       do.call(private$`_to`, args)
     },
+    bool = function(memory_format = torch_preserve_format()) {
+      self$to(torch_bool(), memory_format = memory_format)
+    },
     cuda = function(device=NULL, non_blocking=FALSE, memory_format=torch_preserve_format()) {
       
       if (is.null(device))

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -309,10 +309,10 @@ test_that("tensor$bool works", {
   x <- torch_tensor(c(1,0,1))
   result <- x$bool()
   expected <- x$to(torch_bool())
-  expect_equal(result, expected)
+  expect_equal_to_tensor(result, expected)
 
   expect_silent(
     result <- x$bool(memory_format = torch_contiguous_format())
   )
-  expect_equal(result, expected)
+  expect_equal_to_tensor(result, expected)
 })

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -304,3 +304,15 @@ test_that("element_size works", {
     expect_true(length(result) == 1)
   }
 })
+
+test_that("tensor$bool works", {
+  x <- torch_tensor(c(1,0,1))
+  result <- x$bool()
+  expected <- x$to(torch_bool())
+  expect_equal(result, expected)
+
+  expect_silent(
+    result <- x$bool(memory_format = torch_contiguous_format())
+  )
+  expect_equal(result, expected)
+})


### PR DESCRIPTION
According to the pytorch docs:
> self.bool() is equivalent to self.to(torch.bool)

I haven't found a way to check the memory format, so I just test for no errors, assuming that `$to` works correctly.

Relates to #240