### PR TITLE
Check md5 hashes of pytorch libraries after download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Imports:
     utils,
     stats,
     bit64,
-    magrittr
+    magrittr,
+    tools
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Suggests:


### PR DESCRIPTION
A first proposal to check the pytorch files after installation. I am open to any suggestions.

Current idea is to hardcode md5 hashes along the URLs to pytorch in the `install_config`. Then during installation compare the two hashes and give a somewhat informative error messages, if that fails.
The downloaded file now also gets deleted after the function is exited. In case it was really a malicious file it would be nice to get rid of it asap :)

Relates to #324