### PR TITLE
Link to contributing guidelines in readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -67,4 +67,4 @@ b$grad
 ## Contributing
 
 No matter your current skills it's possible to contribute to `torch` development.
-See the contributing guide for more information.
+See the [contributing guide](https://github.com/mlverse/torch/blob/master/.github/CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -78,4 +78,6 @@ b$grad
 ## Contributing
 
 No matter your current skills it’s possible to contribute to `torch`
-development. See the contributing guide for more information.
+development. See the [contributing
+guide](https://github.com/mlverse/torch/blob/master/.github/CONTRIBUTING.md)
+for more information.


### PR DESCRIPTION
Just a minor thing: I thought it would be nice to directly link to the contributing guidelines from the readme as well.