### PR TITLE
[doc] update getting-started

### DIFF
--- a/vignettes/getting-started/control-flow-and-weight-sharing.Rmd
+++ b/vignettes/getting-started/control-flow-and-weight-sharing.Rmd
@@ -86,7 +86,7 @@ loss_fn <- nnf_mse_loss
 # optimization algorithms. The first argument to the Adam constructor tells the
 # optimizer which Tensors it should update.
 learning_rate <- 1e-4
-optimizer <- optim_sgd(model$parameters, lr=learning_rate, momentum = 0.9)
+optimizer <- optim_adam(model$parameters, lr=learning_rate)
 
 for (t in seq_len(500)) {
    # Forward pass: compute predicted y by passing x to the model. Module objects


### PR DESCRIPTION
text/code mismatch in https://torch.mlverse.org/docs/articles/getting-started/control-flow-and-weight-sharing.html
`The first argument to the Adam constructor tells the [...]` 

new result:

```
Step: 1 : 1.01752 
Step: 100 : 0.6261083 
Step: 200 : 0.2703869 
Step: 300 : 0.1696484 
Step: 400 : 0.06325339 
Step: 500 : 0.03317686 
```