### PR TITLE
make argmax and argmin return 1-based indexes

### DIFF
--- a/R/gen-method.R
+++ b/R/gen-method.R
@@ -794,7 +794,7 @@ call_c_function(
   return_types = return_types,
   fun_type = 'method'
 )})
-Tensor$set("public", "argmax", function(dim = NULL, keepdim = FALSE) {  args <- mget(x = c("dim", "keepdim"))
+Tensor$set("private", "_argmax", function(dim = NULL, keepdim = FALSE) {  args <- mget(x = c("dim", "keepdim"))
 args <- append(list(self = self), args)
 expected_types <- list(self = "Tensor", dim = "int64_t", keepdim = "bool")
 nd_args <- "self"
@@ -807,7 +807,7 @@ call_c_function(
   return_types = return_types,
   fun_type = 'method'
 )})
-Tensor$set("public", "argmin", function(dim = NULL, keepdim = FALSE) {  args <- mget(x = c("dim", "keepdim"))
+Tensor$set("private", "_argmin", function(dim = NULL, keepdim = FALSE) {  args <- mget(x = c("dim", "keepdim"))
 args <- append(list(self = self), args)
 expected_types <- list(self = "Tensor", dim = "int64_t", keepdim = "bool")
 nd_args <- "self"

--- a/R/gen-namespace.R
+++ b/R/gen-namespace.R
@@ -4706,8 +4706,8 @@ fun_type = 'namespace'
 }
 
 
-#' @rdname torch_argmax
-torch_argmax <- function(self, dim = NULL, keepdim = FALSE) {
+#' @rdname .torch_argmax
+.torch_argmax <- function(self, dim = NULL, keepdim = FALSE) {
   args <- mget(x = c("self", "dim", "keepdim"))
 expected_types <- list(self = "Tensor", dim = "int64_t", keepdim = "bool")
 nd_args <- "self"
@@ -4723,8 +4723,8 @@ fun_type = 'namespace'
 }
 
 
-#' @rdname torch_argmin
-torch_argmin <- function(self, dim = NULL, keepdim = FALSE) {
+#' @rdname .torch_argmin
+.torch_argmin <- function(self, dim = NULL, keepdim = FALSE) {
   args <- mget(x = c("self", "dim", "keepdim"))
 expected_types <- list(self = "Tensor", dim = "int64_t", keepdim = "bool")
 nd_args <- "self"

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -190,6 +190,16 @@ Tensor <- R7Class(
     },
     argsort = function(dim = -1L, descending = FALSE) {
       private$`_argsort`(dim = dim, descending = descending)$add_(1L, 1L)
+    },
+    argmax = function(dim = NULL, keepdim = FALSE) {
+      o <- private$`_argmax`(dim = dim, keepdim = keepdim)
+      o <- o$add_(1L, 1L)
+      o
+    },
+    argmin = function(dim = NULL, keepdim = FALSE) {
+      o <- private$`_argmin`(dim = dim, keepdim = keepdim)
+      o <- o$add_(1L, 1L)
+      o
     }
   ),
   active = list(

--- a/R/with-indices.R
+++ b/R/with-indices.R
@@ -52,6 +52,18 @@ torch_min <- function(self, dim, other, keepdim = FALSE) {
   o
 }
 
+torch_argmax <- function(self, dim = NULL, keepdim = FALSE) {
+  o <- .torch_argmax(self, dim = dim, keepdim = keepdim)
+  o$add_(1L, 1L)
+  o
+}
+
+torch_argmin <- function(self, dim = NULL, keepdim = FALSE) {
+  o <- .torch_argmin(self, dim = dim, keepdim = keepdim)
+  o$add_(1L, 1L)
+  o
+}
+
 torch_nll_loss <- function(self, target, weight = list(), reduction = torch_reduction_mean(), ignore_index = -100) {
   target <- target$sub(1L, 1L)
   .torch_nll_loss(self, target, weight, reduction, ignore_index)

--- a/tests/testthat/test-with-indices.R
+++ b/tests/testthat/test-with-indices.R
@@ -30,3 +30,35 @@ test_that("argsort", {
   expect_equal_to_r(x$argsort(dim = 2)[,1], rep(1, 5))
   
 })
+
+test_that("argmax", {
+  
+  x <- torch_tensor(c(1,2,3))
+  expect_equal_to_r(torch_argmax(x), 3)
+  expect_equal_to_r(x$argmax(), 3)
+  
+  x <- torch_tensor(c(3,2,1))
+  expect_equal_to_r(torch_argmax(x), 1)
+  expect_equal_to_r(x$argmax(), 1)
+  
+  x <- torch_tensor(1:9)$reshape(c(3,3))
+  expect_equal_to_r(torch_argmax(x, dim = 2), c(3,3,3))
+  expect_equal(torch_argmax(x, dim = 2, keepdim = TRUE)$shape, c(3,1))
+  
+})
+
+test_that("argmin", {
+  
+  x <- torch_tensor(c(1,2,3))
+  expect_equal_to_r(torch_argmin(x), 1)
+  expect_equal_to_r(x$argmin(), 1)
+  
+  x <- torch_tensor(c(3,2,1))
+  expect_equal_to_r(torch_argmin(x), 3)
+  expect_equal_to_r(x$argmin(), 3)
+  
+  x <- torch_tensor(1:9)$reshape(c(3,3))
+  expect_equal_to_r(torch_argmin(x, dim = 2), c(1,1,1))
+  expect_equal(torch_argmin(x, dim = 2, keepdim = TRUE)$shape, c(3,1))
+  
+})

--- a/tools/torchgen/R/r.R
+++ b/tools/torchgen/R/r.R
@@ -110,7 +110,8 @@ internal_funs <- c("logical_not", "max_pool1d_with_indices", "max_pool2d_with_in
                    "upsample_nearest1d", "upsample_nearest2d", "upsample_nearest3d", "upsample_trilinear3d",
                    "atleast_1d", "atleast_2d", "atleast_3d",
                    "dequantize", "kaiser_window", "vander",
-                   "movedim", "argsort", "norm")
+                   "movedim", "argsort", "norm",
+                   "argmax", "argmin")
 
 internal_funs <- c(internal_funs, creation_ops)
 
@@ -354,7 +355,7 @@ r_method <- function(decls) {
 internal_methods <- c("backward", "retain_grad", "size", "to", "stride",
                       "copy_", "topk", "scatter_", "scatter", "rename",
                       "rename_", "narrow", "narrow_copy", "is_leaf", "max",
-                      "min", "argsort")
+                      "min", "argsort", "argmax", "argmin")
 
 r_method_env <- function(decls) {
   if (decls[[1]]$name %in% internal_methods)


### PR DESCRIPTION
Fix #383 