### PR TITLE
lantern: Fix incompatible redefinition of LANTERN_HOST_HANDLER

### DIFF
--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -32,7 +32,8 @@
 #endif
 
 #ifndef LANTERN_HOST_HANDLER
-#define LANTERN_HOST_HANDLER
+void lantern_host_handler();
+#define LANTERN_HOST_HANDLER lantern_host_handler();
 #endif
 
 #include <stdint.h>

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -32,7 +32,8 @@
 #endif
 
 #ifndef LANTERN_HOST_HANDLER
-#define LANTERN_HOST_HANDLER
+void lantern_host_handler();
+#define LANTERN_HOST_HANDLER lantern_host_handler();
 #endif
 
 #include <stdint.h>

--- a/src/torch_types.h
+++ b/src/torch_types.h
@@ -3,9 +3,6 @@
 #include <string>
 #include <memory>
 
-void lantern_host_handler();
-#define LANTERN_HOST_HANDLER lantern_host_handler();
-
 #include "lantern/lantern.h"
 
 #include <Rcpp.h>


### PR DESCRIPTION
Fixes the following warning:

```
  In file included from device.cpp(2):
  torch_types.h(7): warning # 47: incompatible redefinition of macro "LANTERN_HOST_HANDLER" (declared at line 35 of "lantern/lantern.h")
    #define LANTERN_HOST_HANDLER lantern_host_handler();
```