### PR TITLE
Remove redundant `lantern_host_handler()` in `utils.hpp`

### DIFF
--- a/lantern/src/utils.hpp
+++ b/lantern/src/utils.hpp
@@ -77,5 +77,3 @@ auto optional(void *x)
   auto z = ((LanternObject<T> *)x)->get();
   return std::make_shared<LanternObject<c10::optional<T>>>(z);
 }
-
-void lantern_host_handler();


### PR DESCRIPTION
`lantern_host_handler()` is defined in `lantern.h`, which is already included.