### PR TITLE
Simplify R7 classes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,5 @@ tools/torchgen/.Rbuildignore
 ^CRAN-RELEASE$
 # uncomment below for CRAN submission
 # ^inst/deps/.*
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ lantern/cmake-build*
 check/
 docs/
 public
+doc
+Meta

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -8933,3 +8933,15 @@ cpp_variable_list_to_r_list <- function(x) {
     .Call('_torch_cpp_variable_list_to_r_list', PACKAGE = 'torchpkg', x)
 }
 
+xptr_address <- function(s) {
+    .Call('_torch_xptr_address', PACKAGE = 'torchpkg', s)
+}
+
+set_xptr_address <- function(s, p) {
+    .Call('_torch_set_xptr_address', PACKAGE = 'torchpkg', s, p)
+}
+
+set_xptr_protected <- function(s, pro) {
+    .Call('_torch_set_xptr_protected', PACKAGE = 'torchpkg', s, pro)
+}
+

--- a/R/codegen-utils.R
+++ b/R/codegen-utils.R
@@ -37,10 +37,10 @@ argument_to_torch_type <- function(obj, expected_types, arg_name) {
     return(NULL)
   
   if (any(arg_name == c("index", "indices", "dims")) && any("Tensor" == expected_types) && is_torch_tensor(obj))
-    return(list(get("ptr", as_1_based_tensor(obj), inherits = FALSE), "Tensor"))
+    return(list(as_1_based_tensor(obj), "Tensor"))
   
   if (any("Tensor" == expected_types) && is_torch_tensor(obj))
-    return(list(get("ptr", obj, inherits = FALSE), "Tensor"))
+    return(list(obj, "Tensor"))
   
   if (any("Scalar" == expected_types) && is_torch_scalar(obj))
     return(list(obj$ptr, "Scalar"))

--- a/R/optim-adadelta.R
+++ b/R/optim-adadelta.R
@@ -37,20 +37,21 @@ optim_Adadelta <- R6::R6Class(
         # }
 
         # state initialization
-        if (length(param$state) == 0) {
-          param$state <- list()
-          param$state[["step"]]       <- 0
-          param$state[["square_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
-          param$state[["acc_delta"]]  <- torch_zeros_like(param, memory_format=torch_preserve_format())
+        if (length(state(param)) == 0) {
+          
+          state(param) <- list()
+          state(param)[["step"]]       <- 0
+          state(param)[["square_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+          state(param)[["acc_delta"]]  <- torch_zeros_like(param, memory_format=torch_preserve_format())
         }
 
-        square_avg <- param$state[["square_avg"]]
-        acc_delta  <- param$state[["acc_delta"]]
+        square_avg <- state(param)[["square_avg"]]
+        acc_delta  <- state(param)[["acc_delta"]]
 
         rho <- group[["rho"]]
         eps <- group[["eps"]]
 
-        param$state[["step"]] <- param$state[["step"]] + 1
+        state(param)[["step"]] <- state(param)[["step"]] + 1
 
         if (group[["weight_decay"]] != 0)
           grad <- grad$add(param, alpha=group[["weight_decay"]])

--- a/R/optim-adam.R
+++ b/R/optim-adam.R
@@ -43,27 +43,27 @@ optim_Adam <- R6::R6Class(
         amsgrad <- group$amsgrad
         
         # state initialization
-        if (length(param$state) == 0) {
-          param$state <- list()
-          param$state[["step"]] <- 0
-          param$state[["exp_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
-          param$state[["exp_avg_sq"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+        if (length(state(param)) == 0) {
+          state(param) <- list()
+          state(param)[["step"]] <- 0
+          state(param)[["exp_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+          state(param)[["exp_avg_sq"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
           if (amsgrad) {
-            param$state[['max_exp_avg_sq']] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+            state(param)[['max_exp_avg_sq']] <- torch_zeros_like(param, memory_format=torch_preserve_format())
           }
         }
         
-        exp_avg <- param$state[["exp_avg"]]
-        exp_avg_sq <- param$state[["exp_avg_sq"]]
+        exp_avg <- state(param)[["exp_avg"]]
+        exp_avg_sq <- state(param)[["exp_avg_sq"]]
         if (amsgrad) {
-          max_exp_avg_sq <- param$state[['max_exp_avg_sq']]
+          max_exp_avg_sq <- state(param)[['max_exp_avg_sq']]
         }
         beta1 <- group$betas[[1]]
         beta2 <- group$betas[[2]]
         
-        param$state[["step"]] <- param$state[["step"]] + 1
-        bias_correction1 <- 1 - beta1 ^ param$state[['step']]
-        bias_correction2 <- 1 - beta2 ^ param$state[['step']]
+        state(param)[["step"]] <- state(param)[["step"]] + 1
+        bias_correction1 <- 1 - beta1 ^ state(param)[['step']]
+        bias_correction2 <- 1 - beta2 ^ state(param)[['step']]
         
         if (group$weight_decay != 0) {
           grad$add_(p, alpha=group$weight_decay)

--- a/R/optim-asgd.R
+++ b/R/optim-asgd.R
@@ -26,35 +26,35 @@ optim_ASGD <- R6::R6Class(
       private$step_helper(closure, function(group, param, g, p) {
         grad <- param$grad
         
-        if (length(param$state) == 0) {
-          param$state <- list()
-          param$state[["step"]] <- 0
-          param$state[["eta"]] <- group[["lr"]]
-          param$state[["mu"]] <- 1
-          param$state[["ax"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+        if (length(state(param)) == 0) {
+          state(param) <- list()
+          state(param)[["step"]] <- 0
+          state(param)[["eta"]] <- group[["lr"]]
+          state(param)[["mu"]] <- 1
+          state(param)[["ax"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
         }
         
-        param$state[["step"]] <- param$state[["step"]] + 1
+        state(param)[["step"]] <- state(param)[["step"]] + 1
         
         if (group[["weight_decay"]] != 0)
           grad <- grad$add(param, alpha=group$weight_decay)
         
         # decay term
-        param$mul_(1 - group$lambda * param$state$eta)
+        param$mul_(1 - group$lambda * state(param)$eta)
         
         # update parameter
-        param$add_(grad, alpha=-param$state$eta)
+        param$add_(grad, alpha=-state(param)$eta)
         
         # averaging
-        if (param$state[["mu"]] != 1)
-          param$state[["mu"]]$add_(param$sub(param$state[["ax"]])$mul(param$state[["mu"]]))
+        if (state(param)[["mu"]] != 1)
+          state(param)[["mu"]]$add_(param$sub(state(param)[["ax"]])$mul(state(param)[["mu"]]))
         else
-          param$state[["ax"]]$copy_(param)
+          state(param)[["ax"]]$copy_(param)
         
         # update eta and mu
-        denominator <- (1 + group[["lambda"]] * group[["lr"]] * param$state[["step"]]) ^ group[["alpha"]]
-        param$state[["eta"]] <- group[["lr"]] / denominator
-        param$state[["mu"]] <- 1 / max(1, param$state[["step"]]- group[["t0"]])
+        denominator <- (1 + group[["lambda"]] * group[["lr"]] * state(param)[["step"]]) ^ group[["alpha"]]
+        state(param)[["eta"]] <- group[["lr"]] / denominator
+        state(param)[["mu"]] <- 1 / max(1, state(param)[["step"]]- group[["t0"]])
       })
     }
   )

--- a/R/optim-lbfgs.R
+++ b/R/optim-lbfgs.R
@@ -57,12 +57,12 @@ optim_LBFGS <- R6::R6Class(
         
         # NOTE: LBFGS has only global state, but we register it as state for
         # the first param, because this helps with casting in load_state_dict
-        if (is.null(private$.params[[1]]$state)) {
-          private$.params[[1]]$state <- new.env(parent = emptyenv())
-          private$.params[[1]]$state[["func_evals"]] <- 0
-          private$.params[[1]]$state[["n_iter"]] <- 0
+        if (is.null(state(private$.params[[1]]))) {
+          state(private$.params[[1]]) <- new.env(parent = emptyenv())
+          state(private$.params[[1]])[["func_evals"]] <- 0
+          state(private$.params[[1]])[["n_iter"]] <- 0
         }
-        state <- private$.params[[1]]$state
+        state <- state(private$.params[[1]])
           
         # evaluate initial f(x) and df/dx
         orig_loss <- closure_()

--- a/R/optim-rmsprop.R
+++ b/R/optim-rmsprop.R
@@ -37,23 +37,23 @@ optim_RMSprop <- R6::R6Class(
         # }
         
         # state initialization
-        if (length(param$state) == 0) {
-          param$state <- list()
-          param$state[["step"]] <- 0
-          param$state[["square_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+        if (length(state(param)) == 0) {
+          state(param) <- list()
+          state(param)[["step"]] <- 0
+          state(param)[["square_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
           
           if (group$momentum > 0)
-            param$state[["momentum_buffer"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+            state(param)[["momentum_buffer"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
           
           if (group$centered > 0)
-            param$state[["grad_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+            state(param)[["grad_avg"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
           
         }
         
-        square_avg <- param$state[["square_avg"]]
+        square_avg <- state(param)[["square_avg"]]
         alpha <- group[["alpha"]]
         
-        param$state[["step"]] <- param$state[["step"]] + 1
+        state(param)[["step"]] <- state(param)[["step"]] + 1
         
         
         if (group[["weight_decay"]] != 0)
@@ -62,7 +62,7 @@ optim_RMSprop <- R6::R6Class(
         square_avg$mul_(alpha)$addcmul_(grad, grad, value=1 - alpha)
         
         if (group[["centered"]]) {
-          grad_avg <- param$state[["grad_avg"]]
+          grad_avg <- state(param)[["grad_avg"]]
           grad_avg$mul_(alpha)$add_(grad, alpha=1 - alpha)
           avg <- square_avg$addcmul(grad_avg, grad_avg, value=-1)$sqrt_()$add_(group[["eps"]])
         } else {
@@ -70,7 +70,7 @@ optim_RMSprop <- R6::R6Class(
         }
         
         if (group[["momentum"]] > 0) {
-          buf <- param$state[["momentum_buffer"]]
+          buf <- state(param)[["momentum_buffer"]]
           buf$mul_(group[["momentum"]])$addcdiv_(grad, avg)
           param$add_(buf, alpha=-group[["lr"]])
         } else {

--- a/R/optim-rprop.R
+++ b/R/optim-rprop.R
@@ -20,12 +20,12 @@ optim_Rprop <- R6::R6Class(
         
         grad  <- param$grad
         
-        if (length(param$state) == 0) {
-          param$state <- list()
-          param$state[["step"]] <- 0
-          param$state[["prev"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
+        if (length(state(param)) == 0) {
+          state(param) <- list()
+          state(param)[["step"]] <- 0
+          state(param)[["prev"]] <- torch_zeros_like(param, memory_format=torch_preserve_format())
           new_tensor <- torch_zeros_like(grad, memory_format=torch_preserve_format())
-          param$state[["step_size"]] <-  new_tensor$resize_as_(grad)$fill_(group[["lr"]])
+          state(param)[["step_size"]] <-  new_tensor$resize_as_(grad)$fill_(group[["lr"]])
         }
         
         etaminus <-  group[["etas"]][[1]]
@@ -34,11 +34,11 @@ optim_Rprop <- R6::R6Class(
         step_size_min <- group[["step_sizes"]][[1]]
         step_size_max <- group[["step_sizes"]][[2]]
         
-        step_size <- param$state[["step_size"]]
+        step_size <- state(param)[["step_size"]]
         
-        param$state[['step']] <- param$state[['step']] + 1
+        state(param)[['step']] <- state(param)[['step']] + 1
         
-        sign <- grad$mul(param$state[["prev"]])$sign()
+        sign <- grad$mul(state(param)[["prev"]])$sign()
         sign[sign$gt(0)] <- etaplus
         sign[sign$lt(0)] <- etaminus
         sign[sign$eq(0)] <- 1
@@ -54,7 +54,7 @@ optim_Rprop <- R6::R6Class(
         # update parameters
         param$addcmul_(grad$sign(), step_size, value=-1)
         
-        param$state[["prev"]]$copy_(grad)
+        state(param)[["prev"]]$copy_(grad)
       })
     }
   )

--- a/R/optim-sgd.R
+++ b/R/optim-sgd.R
@@ -44,7 +44,7 @@ optim_SGD <- R6::R6Class(
           param_state <- attr(param, "state")
           if (is.null(param_state) || !"momentum_buffer" %in% names(param_state)) {
             buf <- torch_clone(d_p)$detach()
-            attr(self$param_groups[[g]]$params[[p]], "state") <- list(momentum_buffer = buf)
+           state(param) <- list(momentum_buffer = buf)
           } else {
             buf <- param_state$momentum_buffer
             buf$mul_(momentum)$add_(d_p, alpha=1 - dampening)

--- a/R/optim.R
+++ b/R/optim.R
@@ -116,3 +116,12 @@ Optimizer <- R6::R6Class(
     }
   )
 )
+
+state <- function(self) {
+  attr(self, "state")
+}
+
+`state<-` <- function(self, value) {
+  attr(self, "state") <- value
+  self
+}

--- a/R/scalar.R
+++ b/R/scalar.R
@@ -8,12 +8,10 @@ Scalar <- R7Class(
     initialize = function(x, ptr = NULL) {
       
       if (!is.null(ptr)) {
-        self$ptr <- ptr
-        return(NULL)
+        return(ptr)
       }
       
-      self$ptr <- cpp_torch_scalar(x);
-      
+      cpp_torch_scalar(x);
     },
     
     to_r = function() {
@@ -32,13 +30,22 @@ Scalar <- R7Class(
         f <- cpp_torch_scalar_to_int
       
       f(self$ptr)
+    },
+    
+    print = function() {
+      cat("torch_scalar\n")
     }
     
   ),
   
+  
+  
   active = list(
     type = function() {
       torch_dtype$new(ptr = cpp_torch_scalar_dtype(self$ptr))
+    },
+    ptr = function() {
+      self
     }
   )
   

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -7,8 +7,7 @@ Tensor <- R7Class(
                           pin_memory = FALSE, ptr = NULL) {
       
       if (!is.null(ptr)) {
-        self$ptr <- ptr
-        return(NULL)
+        return(ptr)
       }
       
       # infer dtype from data
@@ -37,8 +36,8 @@ Tensor <- R7Class(
       }
       
       
-      self$ptr <- cpp_torch_tensor(data, rev(dimension), options$ptr, 
-                                   requires_grad, inherits(data, "integer64"))
+      cpp_torch_tensor(data, rev(dimension), options$ptr, 
+                       requires_grad, inherits(data, "integer64"))
     },
     print = function(n = 30) {
       cat("torch_tensor\n")
@@ -380,3 +379,7 @@ str.torch_tensor <- function(object, ...) {
   cat(out)
   cat("\n")
 }
+
+Tensor$set("active", "ptr", function() {
+  self
+})

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -29262,6 +29262,41 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// xptr_address
+SEXP xptr_address(SEXP s);
+RcppExport SEXP _torch_xptr_address(SEXP sSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type s(sSEXP);
+    rcpp_result_gen = Rcpp::wrap(xptr_address(s));
+    return rcpp_result_gen;
+END_RCPP
+}
+// set_xptr_address
+SEXP set_xptr_address(SEXP s, SEXP p);
+RcppExport SEXP _torch_set_xptr_address(SEXP sSEXP, SEXP pSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type s(sSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type p(pSEXP);
+    rcpp_result_gen = Rcpp::wrap(set_xptr_address(s, p));
+    return rcpp_result_gen;
+END_RCPP
+}
+// set_xptr_protected
+SEXP set_xptr_protected(SEXP s, SEXP pro);
+RcppExport SEXP _torch_set_xptr_protected(SEXP sSEXP, SEXP proSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type s(sSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type pro(proSEXP);
+    rcpp_result_gen = Rcpp::wrap(set_xptr_protected(s, pro));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_set_lantern_allocator", (DL_FUNC) &_torch_cpp_set_lantern_allocator, 1},
@@ -31497,6 +31532,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_make_function_name", (DL_FUNC) &_torch_cpp_make_function_name, 5},
     {"_torch_cpp_torch_variable_list", (DL_FUNC) &_torch_cpp_torch_variable_list, 1},
     {"_torch_cpp_variable_list_to_r_list", (DL_FUNC) &_torch_cpp_variable_list_to_r_list, 1},
+    {"_torch_xptr_address", (DL_FUNC) &_torch_xptr_address, 1},
+    {"_torch_set_xptr_address", (DL_FUNC) &_torch_set_xptr_address, 2},
+    {"_torch_set_xptr_protected", (DL_FUNC) &_torch_set_xptr_protected, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/indexing.cpp
+++ b/src/indexing.cpp
@@ -217,8 +217,7 @@ XPtrTorchTensorIndex slices_to_index (std::vector<Rcpp::RObject> slices, bool dr
     
     if (Rf_inherits(slice, "torch_tensor"))
     {
-      Rcpp::Environment e = slice;
-      Rcpp::XPtr<XPtrTorchTensor> t = e["ptr"];
+      Rcpp::XPtr<XPtrTorchTensor> t = Rcpp::as<Rcpp::XPtr<XPtrTorchTensor>>(slice);
       
       auto type = std::string(lantern_Dtype_type(lantern_Tensor_dtype(t->get())));
       
@@ -294,8 +293,7 @@ void Tensor_slice_put(Rcpp::XPtr<XPtrTorchTensor> self, Rcpp::Environment e,
   
   if (Rf_inherits(rhs, "torch_tensor"))
   {
-    Rcpp::Environment e = rhs;
-    Rcpp::XPtr<XPtrTorchTensor> t = e["ptr"];
+    Rcpp::XPtr<XPtrTorchTensor> t = Rcpp::as<Rcpp::XPtr<XPtrTorchTensor>>(rhs);
     lantern_Tensor_index_put_tensor_(self->get(), index.get(), t->get());  
     return;
   }

--- a/src/xptr.cpp
+++ b/src/xptr.cpp
@@ -1,0 +1,44 @@
+// Vendored code from https://github.com/randy3k/xptr/blob/master/src/xptr.c
+// MIT Licensed
+// YEAR: 2017
+// COPYRIGHT HOLDER: Randy Lai
+
+#include <R.h>
+#include <Rinternals.h>
+#include <Rdefines.h>
+#include <stdio.h>
+
+void check_is_xptr(SEXP s) {
+  if (TYPEOF(s) != EXTPTRSXP) {
+    error("expect an externalptr");
+  }
+}
+
+void* str2ptr(SEXP p) {
+  if (!isString(p)) error("expect a string of pointer address");
+  return (void*) strtol(CHAR(STRING_PTR(p)[0]), NULL, 0);
+}
+
+// [[Rcpp::export]]
+SEXP xptr_address(SEXP s) {
+  check_is_xptr(s);
+  char* buf[20];
+  sprintf((char*) buf, "%p", R_ExternalPtrAddr(s));
+  return Rf_mkString((char*) buf);
+}
+
+// [[Rcpp::export]]
+SEXP set_xptr_address(SEXP s, SEXP p) {
+  check_is_xptr(s);
+  R_SetExternalPtrAddr(s, str2ptr(p));
+  return R_NilValue;
+}
+
+// [[Rcpp::export]]
+SEXP set_xptr_protected(SEXP s, SEXP pro) {
+  check_is_xptr(s);
+  R_SetExternalPtrProtected(s, pro);
+  return R_NilValue;
+}
+
+

--- a/tests/testthat/helper-optim.R
+++ b/tests/testthat/helper-optim.R
@@ -40,7 +40,7 @@ expect_state_is_updated <- function(opt_fn) {
   y <- 2 * x
   y$backward()
   opt$step()
-  expect_equal(opt$param_groups[[1]]$params[[1]]$state$step, 1)
+  expect_equal(state(opt$param_groups[[1]]$params[[1]])$step, 1)
   opt$step()
-  expect_equal(opt$param_groups[[1]]$params[[1]]$state$step, 2)
+  expect_equal(state(opt$param_groups[[1]]$params[[1]])$step, 2)
 }

--- a/tests/testthat/test-R7.R
+++ b/tests/testthat/test-R7.R
@@ -1,40 +1,40 @@
-context("r7")
-
-test_that("R7Class", {
-  
-  MyClass <- R7Class(
-    "myclass",
-    public = list(
-      initialize = function(x) {
-        self$x <- x
-      },
-      set_x = function(x) {
-        self$x <- x
-      },
-      set_y2 = function(y) {
-        private$set_y(y)
-      }
-    ),
-    active = list(
-      act = function() {
-        self$x
-      }
-    ),
-    private = list(
-      set_y = function(y) {
-        self$y <- y
-      }
-    )
-  )
-  
-  s <- MyClass$new(x = 1)
-  expect_equal(s$x, 1)
-  
-  s$set_x(2)
-  expect_equal(s$x, 2)
-  
-  s$set_y2(4)
-  expect_equal(s$y, 4)
-  
-  expect_equal(s$act, 2)
-})
+# context("r7")
+# 
+# test_that("R7Class", {
+#   
+#   MyClass <- R7Class(
+#     "myclass",
+#     public = list(
+#       initialize = function(x) {
+#         self$x <- x
+#       },
+#       set_x = function(x) {
+#         self$x <- x
+#       },
+#       set_y2 = function(y) {
+#         private$set_y(y)
+#       }
+#     ),
+#     active = list(
+#       act = function() {
+#         self$x
+#       }
+#     ),
+#     private = list(
+#       set_y = function(y) {
+#         "hello"
+#       }
+#     )
+#   )
+#   
+#   s <- MyClass$new(x = 1)
+#   expect_equal(s$x, 1)
+#   
+#   s$set_x(2)
+#   expect_equal(s$x, 2)
+#   
+#   s$set_y2(4)
+#   expect_equal(s$y, 4)
+#   
+#   expect_equal(s$act, 2)
+# })

--- a/tests/testthat/test-optim-lbfgs.R
+++ b/tests/testthat/test-optim-lbfgs.R
@@ -16,9 +16,9 @@ test_that("state updates correctly", {
   }
   
   opt$step(f)
-  expect_equal(opt$param_groups[[1]]$params[[1]]$state$func_evals, 1)
+  expect_equal(state(opt$param_groups[[1]]$params[[1]])$func_evals, 1)
   opt$step(f)
-  expect_equal(opt$param_groups[[1]]$params[[1]]$state$func_evals, 2)
+  expect_equal(state(opt$param_groups[[1]]$params[[1]])$func_evals, 2)
 })
 
 test_that("lbfgs works", {

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -26,6 +26,7 @@ test_that("save a module", {
   
   torch_save(net, fname)
   reloaded_net <- torch_load(fname)
+  gc()
   
   x <- torch_randn(100, 10)
   expect_equal_to_tensor(net(x), reloaded_net(x))
@@ -67,6 +68,8 @@ test_that("save more complicated module", {
 
   torch_save(net, fname)
   reloaded_net <- torch_load(fname)
+  
+  gc()
   
   expect_equal_to_tensor(net$conv1$parameters$weight, 
                          reloaded_net$conv1$parameters$weight) 


### PR DESCRIPTION
This PR will simplify R7 classes so they are just a single object, in our case, a simple external pointer, so it's easy to make R7 classes directly from C++ - which is going to help in #451 .

This is will be a breaking change for anyone that is using tensors as environments, and thus, saving other obejects there. (like we are doing in the optimizers).