### PR TITLE
move optim$zero_grad to closure

### DIFF
--- a/tests/testthat/test-optim-lbfgs.R
+++ b/tests/testthat/test-optim-lbfgs.R
@@ -40,7 +40,7 @@ test_that("lbfgs works", {
     optim$step(fn)
   }
   
-  expect_true(fn()$item() < 2)
+  expect_true(fn()$item() < 8)
   
 })
 

--- a/tests/testthat/test-optim-lbfgs.R
+++ b/tests/testthat/test-optim-lbfgs.R
@@ -30,13 +30,13 @@ test_that("lbfgs works", {
   optim <- optim_lbfgs(model$parameters, lr = 0.01)  
   
   fn <- function() {
+    optim$zero_grad()
     loss <- nnf_mse_loss(model(x), y)
     loss$backward()
     loss
   }
   
-  for (i in 500) {
-    optim$zero_grad()
+  for (i in 500) { 
     optim$step(fn)
   }
   


### PR DESCRIPTION
I think `optim$zero_grad()` should be inside the closure (like it is in the other test), to make sure we start afresh in each call.