### PR TITLE
fix distribution printing

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -173,17 +173,22 @@ Distribution <- R6::R6Class(
     
     print = function(){
     
+      self_list <- as.list(self)
+      
       param_names <- 
         names(self$.arg_constraints)[
-          names(self$.arg_constraints) %in% names(as.list(self))
+          names(self$.arg_constraints) %in% names(self_list)
             ]
       
-      args_string <- paste0(
-        param_names, collapse = ","
+      args_string <- paste(
+        param_names, sapply(self_list[param_names], function(x) {
+          as.array(if (is.function(x)) x() else x)
+        }),
+        sep = "=", collapse = ", "
       )
       
       class_name <- class(self)[1]
-      cat(glue("{class_name} ({args_string})"))
+      cat(glue::glue("{class_name} ({args_string})"))
     }
   ),
   


### PR DESCRIPTION
The `glue()` call wasn't qualified so we got  `Error in glue("{class(self)}") : could not find function "glue"` while printing. Took a look and noticed that we're printing the literal param names so it's not super helpful. This change is a quick fix to get things kinda working, without changing the original logic.

```
distr_normal(0, 1)
# torch_Normal (loc=0, scale=1)
distr_bernoulli(0.3)
# torch_Bernoulli (probs=0.300000011920929, logits=-0.847297847270966)
```

@krzjoa I'm keeping the change minimal to unblock and you can decide what to do with it/add tests later