### PR TITLE
Allow .getbatch for datasets

### DIFF
--- a/R/utils-data-dataloader.R
+++ b/R/utils-data-dataloader.R
@@ -166,6 +166,8 @@ DataLoader <- R6::R6Class(
         
       }
       
+      self$.has_getbatch <- !is.null(dataset$.getbatch)
+      
       if (!is.null(batch_size) && is.null(batch_sampler)) {
         batch_sampler <- BatchSampler$new(sampler, batch_size, drop_last)
       }
@@ -212,10 +214,10 @@ DataLoader <- R6::R6Class(
   ),
   active = list(
     .auto_collation = function() {
-      !is.null(self$batch_sampler)
+      !is.null(self$batch_sampler) && !self$.has_getbatch
     },
     .index_sampler = function() {
-      if (self$.auto_collation) {
+      if (self$.auto_collation || self$.has_getbatch) {
         return(self$batch_sampler)
       } else {
         return(self$sampler)

--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -82,7 +82,10 @@ dataset <- function(name = NULL, inherit = Dataset, ...,
 
 #' @export
 `[.dataset` <- function(x, y) {
-  x$.getitem(y)
+  if (length(y) > 1 && !is.null(x$.getbatch))
+    x$.getbatch(y)
+  else
+    x$.getitem(y)
 }
 
 #' @export

--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -121,6 +121,9 @@ tensor_dataset <- dataset(
         x[index, ..]
     })
   },
+  .getbatch = function(index) {
+    self$.getitem(index)
+  },
   .length = function() {
     self$tensors[[1]]$shape[1]
   }

--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -24,11 +24,20 @@ get_init <- function(x) {
 #' Helper function to create an R6 class that inherits from the abstract `Dataset` class
 #' 
 #' All datasets that represent a map from keys to data samples should subclass this 
-#' class. All subclasses should overwrite the .getitem() method, which supports 
+#' class. All subclasses should overwrite the `.getitem()` method, which supports 
 #' fetching a data sample for a given key. Subclasses could also optionally 
-#' overwrite .length(), which is expected to return the size of the dataset 
-#' (e.g. number of samples) by many ~torch.utils.data.Sampler implementations 
+#' overwrite `.length()`, which is expected to return the size of the dataset 
+#' (e.g. number of samples) used by many sampler implementations 
 #' and the default options of [dataloader()].
+#' 
+#' @section Get a batch of observations
+#' 
+#' By default datasets are iterated by returning each observation/item individually.
+#' Sometimes it's possible to have an optimized implementation to take a batch
+#' of observations (eg, subsetting a tensor by multiple indexes at once is faster than
+#' subsetting once for each index), in this case you can implement a `.getbatch` method
+#' that will be used instead of `.getitem` when getting a batch of observations within
+#' the dataloader.
 #' 
 #' @note 
 #' [dataloader()]  by default constructs a index

--- a/man/dataset.Rd
+++ b/man/dataset.Rd
@@ -31,10 +31,10 @@ objects.}
 }
 \description{
 All datasets that represent a map from keys to data samples should subclass this
-class. All subclasses should overwrite the .getitem() method, which supports
+class. All subclasses should overwrite the \code{.getitem()} method, which supports
 fetching a data sample for a given key. Subclasses could also optionally
-overwrite .length(), which is expected to return the size of the dataset
-(e.g. number of samples) by many ~torch.utils.data.Sampler implementations
+overwrite \code{.length()}, which is expected to return the size of the dataset
+(e.g. number of samples) used by many sampler implementations
 and the default options of \code{\link[=dataloader]{dataloader()}}.
 }
 \note{

--- a/tests/testthat/test-utils-data-dataloader.R
+++ b/tests/testthat/test-utils-data-dataloader.R
@@ -378,3 +378,27 @@ test_that("globals can be found", {
   expect_tensor_shape(dataloader_next(iter), c(10, 5, 5))
   
 })
+
+test_that("datasets can use an optional .getbatch method for speedups", {
+  
+  d <- dataset(
+    initialize = function() {},
+    .getbatch = function(indexes) {
+      list(
+        torch_randn(length(indexes), 10),
+        torch_randn(length(indexes), 1)
+      )
+    },
+    .length = function() {
+      100
+    }
+  )
+  
+  dl <- dataloader(d(), batch_size = 10)
+  coro::loop(for (x in dl) {
+    expect_length(x, 2)
+    expect_tensor_shape(x[[1]], c(10, 10))
+    expect_tensor_shape(x[[2]], c(10, 1))
+  })
+  
+})


### PR DESCRIPTION
This PR allows for a `.getbatch` method in torch datasets. This allows for a faster path if there's a vectorized way to fetch items, like subsetting a data.frame.