### PR TITLE
Implement custom permute_hidden method for nn_lstm.

### DIFF
--- a/R/nn-rnn.R
+++ b/R/nn-rnn.R
@@ -443,6 +443,12 @@ nn_lstm <- nn_module(
       batch_first = batch_first, dropout = dropout, 
       bidirectional = bidirectional, ...
     )
+  },
+  permute_hidden = function(hx, permutation) {
+    if (is.null(permutation))
+      hx
+    else
+      lapply(hx, nn_apply_permutation, permutation)
   }
 )
 

--- a/tests/testthat/test-nn-rnn.R
+++ b/tests/testthat/test-nn-rnn.R
@@ -241,3 +241,31 @@ test_that("rnn gpu", {
   expect_tensor_shape(out[[2]], c(1,1,1))
   
 })
+
+test_that("lstm and gru works with packed sequences", {
+  # regression test for https://github.com/mlverse/torch/issues/499
+  
+  x <- torch_tensor(rbind(
+    c(1, 2, 0, 0),
+    c(1, 2, 3, 0),
+    c(1, 2, 3, 4)
+  ), dtype = torch_float())
+  x <- x[,,newaxis]
+  lens <- torch_tensor(c(2,3,4), dtype = torch_long())
+  
+  p <- nn_utils_rnn_pack_padded_sequence(x, lens, batch_first = TRUE, 
+                                         enforce_sorted = FALSE)
+  
+  rnn <- nn_lstm(1, 4)
+  out <- rnn(p)
+  
+  unpack <- nn_utils_rnn_pad_packed_sequence(out[[1]])
+  expect_tensor_shape(unpack[[1]], c(4, 3, 4))
+  
+  rnn <- nn_gru(1, 4)
+  out <- rnn(p)
+  
+  unpack <- nn_utils_rnn_pad_packed_sequence(out[[1]])
+  expect_tensor_shape(unpack[[1]], c(4, 3, 4))
+  
+})


### PR DESCRIPTION
Fix #499 

We were missing a custom `permute_hidden` method in the `nn_lstm` module. In python: 

https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/rnn.py#L612-L615