### PR TITLE
Allow tracing functions with more than 1 parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     tools,
     coro,
     callr,
-    cli
+    cli,
+    ellipsis
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Suggests:

--- a/R/trace.R
+++ b/R/trace.R
@@ -36,12 +36,12 @@
 #' 
 #' @param func An R function that will be run with `example_inputs`. func arguments 
 #'   and return values must be tensors or (possibly nested) lists that contain tensors.
-#' @param example_inputs example inputs that will be passed to the function while 
+#' @param ... example inputs that will be passed to the function while 
 #'   tracing. The resulting trace can be run with inputs of different types and 
 #'   shapes assuming the traced operations support those types and shapes. 
 #'   `example_inputs` may also be a single Tensor in which case it is automatically 
-#'   wrapped in a list.
-#' @param ... currently unused.
+#'   wrapped in a list. Note that `...` **can not** be named, and the order is 
+#'   respected.
 #' 
 #' @returns An `script_function`
 #' 
@@ -54,9 +54,10 @@
 #' tr_fn(input)
 #'
 #' @export
-jit_trace <- function(func, example_inputs, ...) {
+jit_trace <- function(func, ...) {
   tr_fn <- make_traceable_fn(func)
-  ex_inp <- torch_jit_stack(example_inputs)
+  ellipsis::check_dots_unnamed() # we do not support named arguments
+  ex_inp <- torch_jit_stack(...)
   ptr <- cpp_trace_function(tr_fn, ex_inp$ptr, .compilation_unit)
   new_script_function(ptr)
 }

--- a/man/jit_trace.Rd
+++ b/man/jit_trace.Rd
@@ -4,19 +4,18 @@
 \alias{jit_trace}
 \title{Trace a function and return an executable \code{script_function}.}
 \usage{
-jit_trace(func, example_inputs, ...)
+jit_trace(func, ...)
 }
 \arguments{
 \item{func}{An R function that will be run with \code{example_inputs}. func arguments
 and return values must be tensors or (possibly nested) lists that contain tensors.}
 
-\item{example_inputs}{example inputs that will be passed to the function while
+\item{...}{example inputs that will be passed to the function while
 tracing. The resulting trace can be run with inputs of different types and
 shapes assuming the traced operations support those types and shapes.
 \code{example_inputs} may also be a single Tensor in which case it is automatically
-wrapped in a list.}
-
-\item{...}{currently unused.}
+wrapped in a list. Note that \code{...} \strong{can not} be named, and the order is
+respected.}
 }
 \value{
 An \code{script_function}

--- a/man/nn_multihead_attention.Rd
+++ b/man/nn_multihead_attention.Rd
@@ -88,6 +88,7 @@ heads.
 }
 
 \examples{
+if (torch_is_installed()) {
 \dontrun{
 multihead_attn = nn_multihead_attention(embed_dim, num_heads)
 out <- multihead_attn(query, key, value)
@@ -95,4 +96,5 @@ attn_output <- out[[1]]
 attn_output_weights <- out[[2]]
 }
 
+}
 }

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -125,3 +125,23 @@ test_that("can output a list of tensors", {
   expect_equal_to_tensor(fn(x)[[2]], tr_fn(x)[[2]])
   
 })
+
+test_that("fn can take more than 1 argument", {
+  
+  fn <- function(x, y) {
+    list(x, x + y)
+  }
+  
+  x <- torch_tensor(1)
+  y <- torch_tensor(2)
+  
+  tr_fn <- jit_trace(fn, x, y)
+  expect_equal_to_tensor(fn(x, y)[[1]], tr_fn(x, y)[[1]])
+  expect_equal_to_tensor(fn(x, y)[[2]], tr_fn(x, y)[[2]])
+  
+  expect_error(
+    tr_fn <- jit_trace(fn, x = x, y = y)  
+  )
+  
+})
+


### PR DESCRIPTION
Fix #529

At the moment I think it's better to not support named arguments, so we are only supporting arguments passed in the correct order. We might want to add support for named arguments in the future.