### PR TITLE
Allows loading models in a specified device.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Export the `torch_diff` function and added docs for it. (#565)
 - Dataset's `.getbatch` now takes an integer vector as input instead of a `list()`. (#572)
 - Fixed bug with `tensor$size()` when indexing with negative numbers. (#570)
+- Added a `device` argument to `torch_load()` allowing one to select to which device parameters should be loaded. (#578)
 
 # torch 0.3.0
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9913,8 +9913,8 @@ cpp_torch_tensor_options_print <- function(x) {
     invisible(.Call('_torch_cpp_torch_tensor_options_print', PACKAGE = 'torchpkg', x))
 }
 
-test_fun <- function(x) {
-    .Call('_torch_test_fun', PACKAGE = 'torchpkg', x)
+test_fun_hello <- function(x) {
+    .Call('_torch_test_fun_hello', PACKAGE = 'torchpkg', x)
 }
 
 cpp_trace_function <- function(fn, inputs, compilation_unit) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9749,8 +9749,8 @@ cpp_tensor_save <- function(x) {
     .Call('_torch_cpp_tensor_save', PACKAGE = 'torchpkg', x)
 }
 
-cpp_tensor_load <- function(s) {
-    .Call('_torch_cpp_tensor_load', PACKAGE = 'torchpkg', s)
+cpp_tensor_load <- function(s, device) {
+    .Call('_torch_cpp_tensor_load', PACKAGE = 'torchpkg', s, device)
 }
 
 cpp_load_state_dict <- function(path) {

--- a/R/save.R
+++ b/R/save.R
@@ -42,29 +42,30 @@ torch_save.nn_module <- function(obj, path, ...) {
 #' Loads a saved object
 #'
 #' @param path a path to the saved object 
+#' @param device
 #' 
 #' @family torch_save
 #' 
 #' @export
 #' @concept serialization
-torch_load <- function(path) {
+torch_load <- function(path, device = "cpu") {
   r <- readRDS(path)
   if (r$type == "tensor")
-    torch_load_tensor(r)
+    torch_load_tensor(r, device)
   else if (r$type == "module")
-    torch_load_module(r)
+    torch_load_module(r, device)
 }
 
-torch_load_tensor <- function(obj) {
-  Tensor$new(ptr = cpp_tensor_load(obj$values))
+torch_load_tensor <- function(obj, device) {
+  Tensor$new(ptr = cpp_tensor_load(obj$values, device))
 }
 
-torch_load_module <- function(obj) {
+torch_load_module <- function(obj, device) {
   obj$state_dict <- lapply(obj$state_dict, function(x) {
     con <- rawConnection(x)
     r <- readRDS(con)
     close(con)
-    torch_load_tensor(r)
+    torch_load_tensor(r, device)
   })
   
   if (is.null(obj$version) || (obj$version < 1))

--- a/R/save.R
+++ b/R/save.R
@@ -43,7 +43,8 @@ torch_save.nn_module <- function(obj, path, ...) {
 #'
 #' @param path a path to the saved object 
 #' @param device a device to load tensors to. By default we load to the `cpu` but you can also
-#'   load them to any `cuda` device.
+#'   load them to any `cuda` device. If `NULL` then the device where the tensor has been saved will
+#'   be reused.
 #' 
 #' @family torch_save
 #' 

--- a/R/save.R
+++ b/R/save.R
@@ -57,11 +57,11 @@ torch_load <- function(path, device = "cpu") {
     torch_load_module(r, device)
 }
 
-torch_load_tensor <- function(obj, device) {
+torch_load_tensor <- function(obj, device = NULL) {
   Tensor$new(ptr = cpp_tensor_load(obj$values, device))
 }
 
-torch_load_module <- function(obj, device) {
+torch_load_module <- function(obj, device = NULL) {
   obj$state_dict <- lapply(obj$state_dict, function(x) {
     con <- rawConnection(x)
     r <- readRDS(con)

--- a/R/save.R
+++ b/R/save.R
@@ -42,7 +42,8 @@ torch_save.nn_module <- function(obj, path, ...) {
 #' Loads a saved object
 #'
 #' @param path a path to the saved object 
-#' @param device
+#' @param device a device to load tensors to. By default we load to the `cpu` but you can also
+#'   load them to any `cuda` device.
 #' 
 #' @family torch_save
 #' 

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -462,8 +462,8 @@ extern "C"
   HOST_API bool lantern_Tensor_is_contiguous(void *self) { bool ret = _lantern_Tensor_is_contiguous(self); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API const char  * (LANTERN_PTR _lantern_tensor_save) (void* self);
   HOST_API const char  * lantern_tensor_save(void* self) { const char  * ret = _lantern_tensor_save(self); LANTERN_HOST_HANDLER return ret;}
-  LANTERN_API void * (LANTERN_PTR _lantern_tensor_load) (const char * s);
-  HOST_API void * lantern_tensor_load(const char * s) { void * ret = _lantern_tensor_load(s); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void * (LANTERN_PTR _lantern_tensor_load) (const char * s, void* device);
+  HOST_API void * lantern_tensor_load(const char * s, void* device) { void * ret = _lantern_tensor_load(s, device); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void * (LANTERN_PTR _lantern_test_tensor)();
   HOST_API void * lantern_test_tensor() { void * ret = _lantern_test_tensor(); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void (LANTERN_PTR _lantern_test_print)(void* x); 

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -935,6 +935,20 @@ HOST_API bool lantern_optional_tensor_has_value (void* x)
   return ret;
 }
 
+LANTERN_API void* (LANTERN_PTR _lantern_OptionalDevice_from_device) (void *x, bool is_null);
+HOST_API void* lantern_OptionalDevice_from_device (void *x, bool is_null)
+{
+  void * ret = _lantern_OptionalDevice_from_device(x, is_null);
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
+LANTERN_API void (LANTERN_PTR _lantern_optional_device_delete) (void*x);
+HOST_API void lantern_optional_device_delete (void* x)
+{
+  _lantern_optional_device_delete(x);
+  LANTERN_HOST_HANDLER;
+}
 
   /* Autogen Headers -- Start */
   LANTERN_API void* (LANTERN_PTR _lantern__cast_byte_tensor_bool)(void* self, void* non_blocking);
@@ -6047,6 +6061,8 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(_lantern_optional_tensor_delete);
   LOAD_SYMBOL(_lantern_optional_tensor);
   LOAD_SYMBOL(_lantern_optional_tensor_has_value);
+  LOAD_SYMBOL(_lantern_OptionalDevice_from_device);
+  LOAD_SYMBOL(_lantern_optional_device_delete);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(_lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(_lantern__cast_char_tensor_bool)

--- a/lantern/src/Delete.cpp
+++ b/lantern/src/Delete.cpp
@@ -258,3 +258,10 @@ void _lantern_optional_tensor_delete (void* x)
   lantern_delete<LanternObject<c10::optional<torch::Tensor>>>(x);
   LANTERN_FUNCTION_END_VOID;
 }
+
+void _lantern_optional_device_delete (void* x)
+{
+  LANTERN_FUNCTION_START;
+  lantern_delete<LanternObject<c10::optional<torch::Device>>>(x);
+  LANTERN_FUNCTION_END_VOID;
+}

--- a/lantern/src/Device.cpp
+++ b/lantern/src/Device.cpp
@@ -63,6 +63,31 @@ void *_lantern_Device(const char *type, int64_t index, bool useIndex)
   LANTERN_FUNCTION_END
 }
 
+void* _lantern_OptionalDevice_from_device (void *x, bool is_null)
+{
+  LANTERN_FUNCTION_START
+  c10::optional<torch::Device> out = c10::nullopt;
+  if (!is_null)
+  {
+    out = reinterpret_cast<LanternPtr<torch::Device>*>(x)->get();
+  }
+  return (void *) new LanternPtr<c10::optional<torch::Device>>(out);
+  LANTERN_FUNCTION_END
+}
+
+void* _lantern_OptionalDevice (const char *type, int64_t index, bool useIndex, bool isNULL)
+{
+  LANTERN_FUNCTION_START
+  if (isNULL)
+  {
+    return _lantern_OptionalDevice_from_device(nullptr, true);
+  } else {
+    return _lantern_OptionalDevice_from_device(_lantern_Device(type, index, useIndex), false);
+  }
+  
+  LANTERN_FUNCTION_END
+}
+
 const char *_lantern_Device_type(void *device)
 {
   LANTERN_FUNCTION_START

--- a/lantern/src/Save.cpp
+++ b/lantern/src/Save.cpp
@@ -48,7 +48,7 @@ void * _lantern_tensor_load (const char * s, void* device)
     std::istringstream stream(str);
 
     torch::Tensor t;
-    c10::optional<torch::Device> device_ = reinterpret_cast<LanternObject<c10::optional<torch::Device>>*>(device)->get();
+    c10::optional<torch::Device> device_ = reinterpret_cast<LanternPtr<c10::optional<torch::Device>>*>(device)->get();
     torch::load(t, stream, device_);
     return (void*) new LanternObject<torch::Tensor>(t);
     LANTERN_FUNCTION_END

--- a/lantern/src/Save.cpp
+++ b/lantern/src/Save.cpp
@@ -48,7 +48,7 @@ void * _lantern_tensor_load (const char * s, void* device)
     std::istringstream stream(str);
 
     torch::Tensor t;
-    c10::optional<torch::Device> device_ = reinterpret_cast<LanternPtr<torch::Device>*>(device)->get();
+    c10::optional<torch::Device> device_ = reinterpret_cast<LanternObject<c10::optional<torch::Device>>*>(device)->get();
     torch::load(t, stream, device_);
     return (void*) new LanternObject<torch::Tensor>(t);
     LANTERN_FUNCTION_END

--- a/lantern/src/Save.cpp
+++ b/lantern/src/Save.cpp
@@ -40,7 +40,7 @@ std::size_t _lantern_tensor_serialized_size (const char * s)
     LANTERN_FUNCTION_END_RET(0)
 }
 
-void * _lantern_tensor_load (const char * s) 
+void * _lantern_tensor_load (const char * s, void* device) 
 {
     LANTERN_FUNCTION_START
     std::string str;
@@ -48,7 +48,8 @@ void * _lantern_tensor_load (const char * s)
     std::istringstream stream(str);
 
     torch::Tensor t;
-    torch::load(t, stream);
+    c10::optional<torch::Device> device_ = reinterpret_cast<LanternPtr<torch::Device>*>(device)->get();
+    torch::load(t, stream, device_);
     return (void*) new LanternObject<torch::Tensor>(t);
     LANTERN_FUNCTION_END
 }

--- a/lantern/src/utils.cpp
+++ b/lantern/src/utils.cpp
@@ -199,8 +199,8 @@ void * _lantern_string_new (const char * value)
 void _lantern_print_stuff (void* x)
 {
   LANTERN_FUNCTION_START
-  auto v = reinterpret_cast<LanternObject<c10::optional<int64_t>>*>(x);
-  std::cout << v->get().value() << std::endl;
+  auto v = reinterpret_cast<LanternPtr<c10::optional<torch::Device>>*>(x);
+  std::cout << v->get().value().type() << std::endl;
   LANTERN_FUNCTION_END_VOID
 }
 

--- a/man/torch_load.Rd
+++ b/man/torch_load.Rd
@@ -4,10 +4,13 @@
 \alias{torch_load}
 \title{Loads a saved object}
 \usage{
-torch_load(path)
+torch_load(path, device = "cpu")
 }
 \arguments{
 \item{path}{a path to the saved object}
+
+\item{device}{a device to load tensors to. By default we load to the \code{cpu} but you can also
+load them to any \code{cuda} device.}
 }
 \description{
 Loads a saved object

--- a/man/torch_load.Rd
+++ b/man/torch_load.Rd
@@ -10,7 +10,8 @@ torch_load(path, device = "cpu")
 \item{path}{a path to the saved object}
 
 \item{device}{a device to load tensors to. By default we load to the \code{cpu} but you can also
-load them to any \code{cuda} device.}
+load them to any \code{cuda} device. If \code{NULL} then the device where the tensor has been saved will
+be reused.}
 }
 \description{
 Loads a saved object

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -31834,13 +31834,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_tensor_load
-Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load(std::string s, XPtrTorchDevice device);
+Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load(std::string s, XPtrTorchOptionalDevice device);
 RcppExport SEXP _torch_cpp_tensor_load(SEXP sSEXP, SEXP deviceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type s(sSEXP);
-    Rcpp::traits::input_parameter< XPtrTorchDevice >::type device(deviceSEXP);
+    Rcpp::traits::input_parameter< XPtrTorchOptionalDevice >::type device(deviceSEXP);
     rcpp_result_gen = Rcpp::wrap(cpp_tensor_load(s, device));
     return rcpp_result_gen;
 END_RCPP
@@ -32298,14 +32298,14 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
-// test_fun
-int test_fun(XPtrTorchoptional_index_int64_t x);
-RcppExport SEXP _torch_test_fun(SEXP xSEXP) {
+// test_fun_hello
+int test_fun_hello(XPtrTorchOptionalDevice x);
+RcppExport SEXP _torch_test_fun_hello(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrTorchoptional_index_int64_t >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(test_fun(x));
+    Rcpp::traits::input_parameter< XPtrTorchOptionalDevice >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(test_fun_hello(x));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -34966,7 +34966,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_tensor_list_to_r_list", (DL_FUNC) &_torch_cpp_tensor_list_to_r_list, 1},
     {"_torch_cpp_torch_tensor_options", (DL_FUNC) &_torch_cpp_torch_tensor_options, 5},
     {"_torch_cpp_torch_tensor_options_print", (DL_FUNC) &_torch_cpp_torch_tensor_options_print, 1},
-    {"_torch_test_fun", (DL_FUNC) &_torch_test_fun, 1},
+    {"_torch_test_fun_hello", (DL_FUNC) &_torch_test_fun_hello, 1},
     {"_torch_cpp_trace_function", (DL_FUNC) &_torch_cpp_trace_function, 3},
     {"_torch_cpp_save_traced_fn", (DL_FUNC) &_torch_cpp_save_traced_fn, 2},
     {"_torch_cpp_jit_compilation_unit", (DL_FUNC) &_torch_cpp_jit_compilation_unit, 0},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -31834,13 +31834,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_tensor_load
-Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load(std::string s);
-RcppExport SEXP _torch_cpp_tensor_load(SEXP sSEXP) {
+Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load(std::string s, XPtrTorchDevice device);
+RcppExport SEXP _torch_cpp_tensor_load(SEXP sSEXP, SEXP deviceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type s(sSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_tensor_load(s));
+    Rcpp::traits::input_parameter< XPtrTorchDevice >::type device(deviceSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_tensor_load(s, device));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -34924,7 +34925,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_torch_reduction_none", (DL_FUNC) &_torch_cpp_torch_reduction_none, 0},
     {"_torch_cpp_torch_reduction_sum", (DL_FUNC) &_torch_cpp_torch_reduction_sum, 0},
     {"_torch_cpp_tensor_save", (DL_FUNC) &_torch_cpp_tensor_save, 1},
-    {"_torch_cpp_tensor_load", (DL_FUNC) &_torch_cpp_tensor_load, 1},
+    {"_torch_cpp_tensor_load", (DL_FUNC) &_torch_cpp_tensor_load, 2},
     {"_torch_cpp_load_state_dict", (DL_FUNC) &_torch_cpp_load_state_dict, 1},
     {"_torch_cpp_torch_scalar", (DL_FUNC) &_torch_cpp_torch_scalar, 1},
     {"_torch_cpp_torch_scalar_dtype", (DL_FUNC) &_torch_cpp_torch_scalar_dtype, 1},

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -462,8 +462,8 @@ extern "C"
   HOST_API bool lantern_Tensor_is_contiguous(void *self) { bool ret = _lantern_Tensor_is_contiguous(self); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API const char  * (LANTERN_PTR _lantern_tensor_save) (void* self);
   HOST_API const char  * lantern_tensor_save(void* self) { const char  * ret = _lantern_tensor_save(self); LANTERN_HOST_HANDLER return ret;}
-  LANTERN_API void * (LANTERN_PTR _lantern_tensor_load) (const char * s);
-  HOST_API void * lantern_tensor_load(const char * s) { void * ret = _lantern_tensor_load(s); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void * (LANTERN_PTR _lantern_tensor_load) (const char * s, void* device);
+  HOST_API void * lantern_tensor_load(const char * s, void* device) { void * ret = _lantern_tensor_load(s, device); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void * (LANTERN_PTR _lantern_test_tensor)();
   HOST_API void * lantern_test_tensor() { void * ret = _lantern_test_tensor(); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void (LANTERN_PTR _lantern_test_print)(void* x); 

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -935,6 +935,20 @@ HOST_API bool lantern_optional_tensor_has_value (void* x)
   return ret;
 }
 
+LANTERN_API void* (LANTERN_PTR _lantern_OptionalDevice_from_device) (void *x, bool is_null);
+HOST_API void* lantern_OptionalDevice_from_device (void *x, bool is_null)
+{
+  void * ret = _lantern_OptionalDevice_from_device(x, is_null);
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
+LANTERN_API void (LANTERN_PTR _lantern_optional_device_delete) (void*x);
+HOST_API void lantern_optional_device_delete (void* x)
+{
+  _lantern_optional_device_delete(x);
+  LANTERN_HOST_HANDLER;
+}
 
   /* Autogen Headers -- Start */
   LANTERN_API void* (LANTERN_PTR _lantern__cast_byte_tensor_bool)(void* self, void* non_blocking);
@@ -6047,6 +6061,8 @@ bool lanternInit(const std::string &libPath, std::string *pError)
   LOAD_SYMBOL(_lantern_optional_tensor_delete);
   LOAD_SYMBOL(_lantern_optional_tensor);
   LOAD_SYMBOL(_lantern_optional_tensor_has_value);
+  LOAD_SYMBOL(_lantern_OptionalDevice_from_device);
+  LOAD_SYMBOL(_lantern_optional_device_delete);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(_lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(_lantern__cast_char_tensor_bool)

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -11,7 +11,7 @@ std::string cpp_tensor_save (Rcpp::XPtr<XPtrTorchTensor> x)
 }
 
 // [[Rcpp::export]]
-Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load (std::string s, XPtrTorchDevice device)
+Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load (std::string s, XPtrTorchOptionalDevice device)
 {
   XPtrTorchTensor t = lantern_tensor_load(s.c_str(), device.get());
   return make_xptr<XPtrTorchTensor>(t);

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -11,9 +11,9 @@ std::string cpp_tensor_save (Rcpp::XPtr<XPtrTorchTensor> x)
 }
 
 // [[Rcpp::export]]
-Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load (std::string s)
+Rcpp::XPtr<XPtrTorchTensor> cpp_tensor_load (std::string s, XPtrTorchDevice device)
 {
-  XPtrTorchTensor t = lantern_tensor_load(s.c_str());
+  XPtrTorchTensor t = lantern_tensor_load(s.c_str(), device.get());
   return make_xptr<XPtrTorchTensor>(t);
 }
 

--- a/src/torch_types.cpp
+++ b/src/torch_types.cpp
@@ -371,6 +371,23 @@ XPtrTorchDevice XPtrTorchDevice_from_SEXP (SEXP x)
 XPtrTorchDevice::XPtrTorchDevice (SEXP x):
   XPtrTorch{XPtrTorchDevice_from_SEXP(x)} {}
 
+XPtrTorchOptionalDevice XPtrTorchOptionalDevice_from_SEXP (SEXP x)
+{
+  std::cout << "getting data"<< std::endl;
+  if (TYPEOF(x) == NILSXP)
+  {
+    return XPtrTorchOptionalDevice(lantern_OptionalDevice_from_device(nullptr, true));
+  } 
+  else 
+  {
+    std::cout << "getting data2"<< std::endl;
+    return XPtrTorchOptionalDevice(lantern_OptionalDevice_from_device(XPtrTorchDevice_from_SEXP(x).get(), false));
+  }
+}
+
+XPtrTorchOptionalDevice::XPtrTorchOptionalDevice (SEXP x):
+  XPtrTorch{XPtrTorchOptionalDevice_from_SEXP(x)} {}
+
 XPtrTorchDtype XPtrTorchDtype_from_SEXP (SEXP x)
 {
   if (TYPEOF(x) == EXTPTRSXP && Rf_inherits(x, "torch_dtype")) {
@@ -676,8 +693,9 @@ XPtrTorchoptional_index_int64_t::XPtrTorchoptional_index_int64_t (SEXP x_)
 }
 
 // [[Rcpp::export]]
-int test_fun (XPtrTorchoptional_index_int64_t x)
+int test_fun_hello (XPtrTorchOptionalDevice x)
 {
+  std::cout << "test fun" << std::endl;
   lantern_print_stuff(x.get());
   return 1 + 1;
 }

--- a/src/torch_types.cpp
+++ b/src/torch_types.cpp
@@ -373,14 +373,12 @@ XPtrTorchDevice::XPtrTorchDevice (SEXP x):
 
 XPtrTorchOptionalDevice XPtrTorchOptionalDevice_from_SEXP (SEXP x)
 {
-  std::cout << "getting data"<< std::endl;
   if (TYPEOF(x) == NILSXP)
   {
     return XPtrTorchOptionalDevice(lantern_OptionalDevice_from_device(nullptr, true));
   } 
   else 
   {
-    std::cout << "getting data2"<< std::endl;
     return XPtrTorchOptionalDevice(lantern_OptionalDevice_from_device(XPtrTorchDevice_from_SEXP(x).get(), false));
   }
 }

--- a/src/torch_types.h
+++ b/src/torch_types.h
@@ -118,6 +118,15 @@ public:
   operator SEXP () const;
 };
 
+class XPtrTorchOptionalDevice : public XPtrTorch {
+public:
+  XPtrTorchOptionalDevice (void* x) : XPtrTorch(x, lantern_optional_device_delete) {}
+  explicit XPtrTorchOptionalDevice (std::shared_ptr<void> x) : XPtrTorch(x) {};
+  XPtrTorchOptionalDevice (const XPtrTorchOptionalDevice& x) : XPtrTorch(x.get_shared()) {};
+  explicit XPtrTorchOptionalDevice (SEXP x);
+  operator SEXP () const;
+};
+
 class XPtrTorchDtype : public XPtrTorch {
 public:
   XPtrTorchDtype () : XPtrTorch{NULL} {}

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -199,3 +199,36 @@ test_that("requires_grad of parameters is correct", {
   expect_false(model2$bias$requires_grad)
 })
 
+test_that("save on cuda and load on cpu", {
+  
+  skip_if_cuda_not_available()
+  model <- nn_linear(10, 10)$cuda()
+  
+  expect_equal(model$weight$device$type, "cuda")
+  
+  tmp <- tempfile("model", fileext = "pt")
+  torch_save(model, tmp)
+  
+  mod <- torch_load(tmp)
+  
+  expect_equal(mod$weight$device$type, "cpu")
+  
+})
+
+test_that("save on cuda and load on cuda", {
+  
+  skip_if_cuda_not_available()
+  model <- nn_linear(10, 10)$cuda()
+  
+  expect_equal(model$weight$device$type, "cuda")
+  
+  tmp <- tempfile("model", fileext = "pt")
+  torch_save(model, tmp)
+  
+  mod <- torch_load(tmp, device = "cuda")
+  
+  expect_equal(mod$weight$device$type, "cuda")
+  
+})
+
+

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -201,6 +201,8 @@ test_that("requires_grad of parameters is correct", {
 
 test_that("can save with a NULL device", {
   
+  skip_if_cuda_not_available()
+  
   model <- nn_linear(10, 10)$cuda()
   tmp <- tempfile("model", fileext = "pt")
   torch_save(model, tmp)

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -201,10 +201,11 @@ test_that("requires_grad of parameters is correct", {
 
 test_that("can save with a NULL device", {
   
-  model <- nn_linear(10, 10)
+  model <- nn_linear(10, 10)$cuda()
   tmp <- tempfile("model", fileext = "pt")
   torch_save(model, tmp)
-  torch_load(tmp, device = NULL)
+  model <- torch_load(tmp, device = NULL)
+  expect_equal(model$weight$device$type, "cuda")
   
 })
 

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -199,6 +199,15 @@ test_that("requires_grad of parameters is correct", {
   expect_false(model2$bias$requires_grad)
 })
 
+test_that("can save with a NULL device", {
+  
+  model <- nn_linear(10, 10)
+  tmp <- tempfile("model", fileext = "pt")
+  torch_save(model, tmp)
+  torch_load(tmp, device = NULL)
+  
+})
+
 test_that("save on cuda and load on cpu", {
   
   skip_if_cuda_not_available()


### PR DESCRIPTION
This PR adds a `device` argument to `torch_load` that can be specified to load models in that device. The default is `cpu`.
This is a breaking change because models saved on the GPU wold be automatically loaded in the GPU but now they are going to be loaded in the CPU. Users can still specify `device="cuda"` to load parameters in the cuda device or `NULL` to load in whichever device the tensor was when saved.

This not equivalent to `map_location` but is enough to fix a large chunk of use cases. Should fix #395 