### PR TITLE
Persist `training` attribute

### DIFF
--- a/R/script_module.R
+++ b/R/script_module.R
@@ -115,6 +115,15 @@ nn_ScriptModule <- R6::R6Class(
         env = private
       )
       
+      rm(list = "training", envir = self)
+      makeActiveBinding(
+        "training",
+        fun = function() {
+          cpp_jit_script_module_is_training(private$ptr)
+        }, 
+        env = self
+      )
+      
     },
     register_parameter = function(name, param) {
       private$ptr$register_parameter(name, param)
@@ -130,6 +139,10 @@ nn_ScriptModule <- R6::R6Class(
     },
     ..ptr.. = function() {
       private$ptr
+    },
+    train = function(mode = TRUE) {
+      private$ptr$train(mode = mode)
+      invisible(create_nn_module_callable(self))
     }
   ),
   private = list(

--- a/R/trace.R
+++ b/R/trace.R
@@ -229,6 +229,7 @@ create_script_module <- function(mod) {
     module$register_module(name, create_script_module(child))
   })
   
+  module$train(mod$training)
   
   # Let's not keep the constants in the module right now as it might cause more
   # problems than benefits. In pytorch they are only added if their name is in 

--- a/src/script_module.cpp
+++ b/src/script_module.cpp
@@ -16,25 +16,25 @@ XPtrTorchjit_named_buffer_list cpp_jit_script_module_buffers (XPtrTorchScriptMod
 // [[Rcpp::export]]
 void cpp_jit_script_module_train (XPtrTorchScriptModule self, bool on)
 {
-  _lantern_ScriptModule_train(self.get(), on);
+  lantern_ScriptModule_train(self.get(), on);
 }
 
 // [[Rcpp::export]]
 void cpp_jit_script_module_set_optimized (XPtrTorchScriptModule self, bool on)
 {
-  _lantern_ScriptModule_set_optimized(self.get(), on);
+  lantern_ScriptModule_set_optimized(self.get(), on);
 }
 
 // [[Rcpp::export]]
 bool cpp_jit_script_module_is_training (XPtrTorchScriptModule self)
 {
-  return _lantern_ScriptModule_is_training(self.get());
+  return lantern_ScriptModule_is_training(self.get());
 }
 
 // [[Rcpp::export]]
 bool cpp_jit_script_module_is_optimized (XPtrTorchScriptModule self)
 {
-  return _lantern_ScriptModule_is_optimized(self.get());
+  return lantern_ScriptModule_is_optimized(self.get());
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-script_module.R
+++ b/tests/testthat/test-script_module.R
@@ -129,3 +129,19 @@ test_that("can print the graph", {
   })
   
 })
+
+test_that("training attribute is persisted", {
+  model <- nn_sequential(
+    nn_linear(10, 10),
+    nn_relu(),
+    nn_dropout(),
+    nn_linear(10, 1)
+  )
+  
+  model$eval()
+  model$training
+  test_model <- jit_trace(model, torch_randn(10, 10)) 
+  
+  expect_true(!test_model$training)
+  expect_true(!test_model[["0"]]$training)
+})


### PR DESCRIPTION
This should fix #632 but it seems that https://github.com/pytorch/pytorch/issues/62603 is the reson why it doesn't work yet.