### PR TITLE
Pair seeds with PyTorch RNG.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - Allows querying the graph from traced modules. (#623)
 - Added `with_detect_anomaly` to debug autograd errors. (#628)
 - A warning is raised when an incompatible dataset is passed to a parallel dataloader. (#626)
+- `torch_manual_seed()` now matches PyTorch's behavior so we can more easily compare implementations. Since this is a breaking change we added the `torch.old_seed_behavior=TRUE` option so users can stick to the old behavior. (#639)
 
 # torch 0.4.0
 

--- a/R/generator.R
+++ b/R/generator.R
@@ -68,8 +68,10 @@ is_torch_generator <- function(x) {
 torch_manual_seed <- function(seed) {
   cpp_torch_manual_seed(as.character(seed))
   # update the null generator
-  .generator_null$set_current_seed(
-    seed = as.integer(torch::torch_randint(low = 1, high = 1e6, size = 1)$item())
-  )
+  if (torch_option("old_seed_behavior", FALSE)) {
+    .generator_null$set_current_seed(
+      seed = as.integer(torch::torch_randint(low = 1, high = 1e6, size = 1)$item())
+    )  
+  }
 }
 

--- a/R/package.R
+++ b/R/package.R
@@ -33,9 +33,10 @@ globalVariables(c("..", "self", "private", "N"))
       lantern_start()
       cpp_set_lantern_allocator(getOption("torch.threshold_call_gc", 4000L))
       
+      # .generator_null is no longer used. set the option `torch.old_seed_behavior=TRUE` to use it.
       .generator_null <<- torch_generator()
-      .generator_null$set_current_seed(seed = sample(1e5, 1))
-      
+      .generator_null$set_current_seed(seed = sample(1e5, 1))  
+
       .compilation_unit <<- cpp_jit_compilation_unit()
       
     }, error = function(e) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,3 +82,6 @@ seq2 <- function(start, end, by = 1L) {
     seq(start, end, by = by)
 }
 
+torch_option <- function(option, default = NULL) {
+  getOption(paste0("torch.", option), default)
+}

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -1909,6 +1909,14 @@ HOST_API bool lantern_autograd_detect_anomaly_is_enabled ()
   return ret;
 }
 
+LANTERN_API void* (LANTERN_PTR _lantern_get_default_Generator) ();
+HOST_API void* lantern_get_default_Generator ()
+{
+  void* ret = _lantern_get_default_Generator();
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
   /* Autogen Headers -- Start */
   LANTERN_API void* (LANTERN_PTR _lantern__cast_byte_tensor_bool)(void* self, void* non_blocking);
   HOST_API void* lantern__cast_byte_tensor_bool(void* self, void* non_blocking) { void* ret = _lantern__cast_byte_tensor_bool(self, non_blocking); LANTERN_HOST_HANDLER return ret; }
@@ -7485,6 +7493,7 @@ LOAD_SYMBOL(_lantern_contrib_sort_vertices);
 LOAD_SYMBOL(_lantern_ScriptMethod_graph_print);
 LOAD_SYMBOL(_lantern_autograd_set_detect_anomaly);
 LOAD_SYMBOL(_lantern_autograd_detect_anomaly_is_enabled);
+LOAD_SYMBOL(_lantern_get_default_Generator);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(_lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(_lantern__cast_char_tensor_bool)

--- a/lantern/src/Generator.cpp
+++ b/lantern/src/Generator.cpp
@@ -16,6 +16,13 @@ void *_lantern_Generator()
   LANTERN_FUNCTION_END
 }
 
+void* _lantern_get_default_Generator ()
+{
+  LANTERN_FUNCTION_START
+  return (void *)new LanternObject<torch::Generator>(at::detail::getDefaultCPUGenerator());
+  LANTERN_FUNCTION_END
+}
+
 uint64_t _lantern_Generator_current_seed(void *generator)
 {
   LANTERN_FUNCTION_START

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -1909,6 +1909,14 @@ HOST_API bool lantern_autograd_detect_anomaly_is_enabled ()
   return ret;
 }
 
+LANTERN_API void* (LANTERN_PTR _lantern_get_default_Generator) ();
+HOST_API void* lantern_get_default_Generator ()
+{
+  void* ret = _lantern_get_default_Generator();
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
   /* Autogen Headers -- Start */
   LANTERN_API void* (LANTERN_PTR _lantern__cast_byte_tensor_bool)(void* self, void* non_blocking);
   HOST_API void* lantern__cast_byte_tensor_bool(void* self, void* non_blocking) { void* ret = _lantern__cast_byte_tensor_bool(self, non_blocking); LANTERN_HOST_HANDLER return ret; }
@@ -7485,6 +7493,7 @@ LOAD_SYMBOL(_lantern_contrib_sort_vertices);
 LOAD_SYMBOL(_lantern_ScriptMethod_graph_print);
 LOAD_SYMBOL(_lantern_autograd_set_detect_anomaly);
 LOAD_SYMBOL(_lantern_autograd_detect_anomaly_is_enabled);
+LOAD_SYMBOL(_lantern_get_default_Generator);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(_lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(_lantern__cast_char_tensor_bool)

--- a/src/torch_types.cpp
+++ b/src/torch_types.cpp
@@ -829,10 +829,20 @@ XPtrTorchGenerator XPtrTorchGenerator_from_SEXP (SEXP x)
   
   if (TYPEOF(x) == NILSXP)
   {
-    auto out = Rcpp::as<Rcpp::XPtr<XPtrTorchGenerator>>(
-      Rcpp::Environment::namespace_env("torch").find(".generator_null")
-    );
-    return XPtrTorchGenerator( out->get_shared());
+    Rcpp::Function torch_option = Rcpp::Environment::namespace_env("torch").find("torch_option");
+    
+    if (Rcpp::as<bool>(torch_option("old_seed_behavior", false)))
+    {
+      auto out = Rcpp::as<Rcpp::XPtr<XPtrTorchGenerator>>(
+        Rcpp::Environment::namespace_env("torch").find(".generator_null")
+      );  
+      return XPtrTorchGenerator(out->get_shared());
+    }
+    else
+    {
+      return XPtrTorchGenerator(lantern_get_default_Generator());  
+    }
+    
   }
   
   Rcpp::stop("Expected a torch_generator");

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -27,3 +27,15 @@ test_that("manual_seed works", {
   expect_equal_to_tensor(a$bias, b$bias)
   
 })
+
+test_that("current behavior is identical to pytorch", {
+  
+  torch_manual_seed(1)
+  expect_equal_to_r(torch_randn(1), 0.661352157592773)
+  
+  withr::with_options(new = list("torch.old_seed_behavior" = TRUE), {
+    torch_manual_seed(2019)
+    expect_equal_to_r(torch_randn(1), -0.364226043224335)
+  })
+  
+})

--- a/tests/testthat/test-linalg.R
+++ b/tests/testthat/test-linalg.R
@@ -235,6 +235,7 @@ test_that("tensorinv", {
 })
 
 test_that("tensorsolve", {
+  torch_manual_seed(204929)
   A <- torch_eye(2 * 3 * 4)$reshape(c(2 * 3, 4, 2, 3, 4))
   B <- torch_randn(2 * 3, 4)
   X <- linalg_tensorsolve(A, B)

--- a/tests/testthat/test-nn-linear.R
+++ b/tests/testthat/test-nn-linear.R
@@ -10,3 +10,15 @@ test_that("nn_linear", {
   expect_tensor(y)
   expect_length(as_array(y), 10)
 })
+
+test_that("initialization is identical to pytorch", {
+  
+  
+  torch_manual_seed(1)
+  
+  expect_equal(
+    nn_linear(1,1)$weight$item(),
+    0.5152631998062134 #grabbed from pytorch  
+  )
+  
+})

--- a/tests/testthat/test-optim-lbfgs.R
+++ b/tests/testthat/test-optim-lbfgs.R
@@ -22,7 +22,8 @@ test_that("state updates correctly", {
 })
 
 test_that("lbfgs works", {
-  torch_manual_seed(1)
+  
+  torch_manual_seed(3)
   x <- torch_randn(100, 10)
   y <- torch_sum(x, 2, keepdim = TRUE)
   


### PR DESCRIPTION
Default to pairing torch RNG with PyTorch's so its easier to compare implementations.
This is a breaking change so we added the `torch.old_seed_behavior` option so users can still stick to the old behavior.

Fix #636 