### PR TITLE
Improve cuda detection

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,6 +46,7 @@ jobs:
       TORCH_LOG: 2
       TORCH_TEST: 1
       TORCH_INSTALL: 1
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v1

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - A warning is raised when an incompatible dataset is passed to a parallel dataloader. (#626)
 - `torch_manual_seed()` now matches PyTorch's behavior so we can more easily compare implementations. Since this is a breaking change we added the `torch.old_seed_behavior=TRUE` option so users can stick to the old behavior. (#639)
 - Implemented `traced_module$graph_for()` to allow inspecting the optimized jit graph. (#643)
+- Improved CUDA version auto-detection (#644)
 
 # torch 0.4.0
 

--- a/R/install.R
+++ b/R/install.R
@@ -208,11 +208,13 @@ install_type_windows <- function(version) {
 }
 
 nvcc_version_from_path <- function(nvcc) {
-  nvcc <- tryCatch(system2(nvcc, "--version", stdout = TRUE, stderr = TRUE), error = function(e) NULL)
-  if (!is.null(nvcc))
-    gsub(".*release |, V.*", "", nvcc[grepl("release", nvcc)])
-  else
-    NULL
+  suppressWarnings(
+    nvcc <- tryCatch(system2(nvcc, "--version", stdout = TRUE, stderr = TRUE), error = function(e) NULL)  
+  )
+  
+  if (is.null(nvcc) || !any(grepl("release", nvcc))) return(NULL)
+  
+  gsub(".*release |, V.*", "", nvcc[grepl("release", nvcc)])
 }
 
 #' @keywords internal
@@ -251,7 +253,7 @@ install_type <- function(version) {
   
   # Query nvcc from conventional location
   if (is.null(cuda_version)) {
-    cuda_version <- nvcc_version_from_path("/usr/local/cuda/bin")
+    cuda_version <- nvcc_version_from_path("/usr/local/cuda/bin/nvcc")
   }
   
   if (is.null(cuda_version)) {


### PR DESCRIPTION
Improve cuda detection heuristics by querying nvcc from default locations (even if its not on the path).
Fix #638