### PR TITLE
Fix rchk issues.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,7 +22,7 @@ tools/torchgen/.Rbuildignore
 ^cran-comments\.md$
 ^CRAN-RELEASE$
 # uncomment below for CRAN submission
-#^inst/deps/.*
+^inst/deps/.*
 ^doc$
 ^Meta$
 ^vignettes/rsconnect*

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,7 +22,7 @@ tools/torchgen/.Rbuildignore
 ^cran-comments\.md$
 ^CRAN-RELEASE$
 # uncomment below for CRAN submission
-^inst/deps/.*
+#^inst/deps/.*
 ^doc$
 ^Meta$
 ^vignettes/rsconnect*

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 - Added Dockerfiles for CUDA 11.1 (#597)
 - A warning is raised when an incompatible dataset is passed to a parallel dataloader. (#626)
 - Additionally to calling `gc` when CUDA memory is exhausted we now call `R_RunPendingFinalizers`. This should improve memory usage, because we will now delete tensors earlier. (#654)
+- Fix rchk issues (#667)
 
 # torch 0.4.0
 

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -1965,6 +1965,14 @@ HOST_API bool lantern_OptionalTensorList_at_is_null (void* self, int64_t i)
   return ret;
 }
 
+LANTERN_API void* (LANTERN_PTR _lantern_optional_tensor_value) (void* x);
+HOST_API void* lantern_optional_tensor_value (void* x)
+{
+  void* ret = _lantern_optional_tensor_value(x);
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
   /* Autogen Headers -- Start */
   LANTERN_API void* (LANTERN_PTR _lantern__cast_byte_tensor_bool)(void* self, void* non_blocking);
   HOST_API void* lantern__cast_byte_tensor_bool(void* self, void* non_blocking) { void* ret = _lantern__cast_byte_tensor_bool(self, non_blocking); LANTERN_HOST_HANDLER return ret; }
@@ -7548,6 +7556,7 @@ LOAD_SYMBOL(_lantern_OptionalTensorList_delete);
 LOAD_SYMBOL(_lantern_OptionalTensorList_size);
 LOAD_SYMBOL(_lantern_OptionalTensorList_at);
 LOAD_SYMBOL(_lantern_OptionalTensorList_at_is_null);
+LOAD_SYMBOL(_lantern_optional_tensor_value);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(_lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(_lantern__cast_char_tensor_bool)

--- a/lantern/src/Tensor.cpp
+++ b/lantern/src/Tensor.cpp
@@ -287,6 +287,12 @@ bool _lantern_optional_tensor_has_value (void*x)
   return value.has_value();
 }
 
+void* _lantern_optional_tensor_value (void* x)
+{
+  auto value = reinterpret_cast<LanternObject<c10::optional<torch::Tensor>>*>(x)->get();
+  return (void *)new LanternObject<torch::Tensor>(value.value());
+}
+
 void _lantern_tensor_set_pyobj (void*x, void* ptr)
 {
   LANTERN_FUNCTION_START

--- a/src/lantern/lantern.h
+++ b/src/lantern/lantern.h
@@ -1965,6 +1965,14 @@ HOST_API bool lantern_OptionalTensorList_at_is_null (void* self, int64_t i)
   return ret;
 }
 
+LANTERN_API void* (LANTERN_PTR _lantern_optional_tensor_value) (void* x);
+HOST_API void* lantern_optional_tensor_value (void* x)
+{
+  void* ret = _lantern_optional_tensor_value(x);
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
   /* Autogen Headers -- Start */
   LANTERN_API void* (LANTERN_PTR _lantern__cast_byte_tensor_bool)(void* self, void* non_blocking);
   HOST_API void* lantern__cast_byte_tensor_bool(void* self, void* non_blocking) { void* ret = _lantern__cast_byte_tensor_bool(self, non_blocking); LANTERN_HOST_HANDLER return ret; }
@@ -7548,6 +7556,7 @@ LOAD_SYMBOL(_lantern_OptionalTensorList_delete);
 LOAD_SYMBOL(_lantern_OptionalTensorList_size);
 LOAD_SYMBOL(_lantern_OptionalTensorList_at);
 LOAD_SYMBOL(_lantern_OptionalTensorList_at_is_null);
+LOAD_SYMBOL(_lantern_optional_tensor_value);
   /* Autogen Symbols -- Start */
   LOAD_SYMBOL(_lantern__cast_byte_tensor_bool)
   LOAD_SYMBOL(_lantern__cast_char_tensor_bool)

--- a/src/torch_types.cpp
+++ b/src/torch_types.cpp
@@ -49,7 +49,7 @@ XPtrTorchOptionalTensor::operator SEXP() const {
   }
   else 
   {
-    return XPtrTorchTensor(*this);
+    return XPtrTorchTensor(lantern_optional_tensor_value(this->get()));
   }
 }
 
@@ -356,7 +356,7 @@ XPtrTorchIValue::operator SEXP () const
     return Rcpp::wrap(XPtrTorchTensorList(lantern_IValue_TensorList(this->get())));
     
   case IValue_types::IValueTensorType:
-    return Rcpp::wrap(XPtrTorchTensor(lantern_IValue_Tensor(this->get())));
+    return XPtrTorchTensor(lantern_IValue_Tensor(this->get()));
     
   case IValue_types::IValueTupleType:
     return Rcpp::wrap(XPtrTorchNamedTupleHelper(lantern_IValue_Tuple(this->get())));


### PR DESCRIPTION
```
Function XPtrTorchIValue::operator SEXPREC*() const
  [UP] unprotected variable <unnamed var:   %2 = alloca %struct.SEXPREC*, align 8> while calling allocating function XPtrTorchTensor::~XPtrTorchTensor() /rchk/packages/build/9XifUaE0/torch/src/torch_types.cpp:359

Function XPtrTorchOptionalTensor::operator SEXPREC*() const
  [UP] unprotected variable <unnamed var:   %2 = alloca %struct.SEXPREC*, align 8> while calling allocating function XPtrTorchTensor::~XPtrTorchTensor() /rchk/packages/build/9XifUaE0/torch/src/torch_types.cpp:52
```