### PR TITLE
Make `nn_sequential` a bare `nn_module`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 - Fixed bug when indexing with numeric vectors. (#693, @mohamed-180)
 - Fixed bug when indexing tensors with ellipsis and a tensor. (#696)
 - Improved optimizer documentation by adding a 'Warning' regarding the creation and usage order. (#698)
-- `nn_sequential` is now a bare `nn_module`, allowing to easily inherit from it. This is a breaking change if you used the `name` argument. The `name` behavior can be achieved by inheriting see the tests in the PR. (#699)
+- `nn_sequential` is now a bare `nn_module`, allowing to easily inherit from it. This is a breaking change if you used the `name` argument. The `name` behavior can be achieved by subclassing; see the tests in the PR. (#699)
 
 # torch 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Fixed bug when indexing with numeric vectors. (#693, @mohamed-180)
 - Fixed bug when indexing tensors with ellipsis and a tensor. (#696)
 - Improved optimizer documentation by adding a 'Warning' regarding the creation and usage order. (#698)
+- `nn_sequential` is now a bare `nn_module`, allowing to easily inherit from it. This is a breaking change if you used the `name` argument. The `name` behavior can be achieved by inheriting see the tests in the PR. (#699)
 
 # torch 0.5.0
 

--- a/R/nn.R
+++ b/R/nn.R
@@ -588,7 +588,6 @@ print.nn_module <- function(x, ...) {
 #' See examples.
 #' 
 #' @param ... sequence of modules to be added
-#' @param name optional name for the generated module.
 #' 
 #' @examples 
 #' 
@@ -602,24 +601,21 @@ print.nn_module <- function(x, ...) {
 #' output <- model(input)
 #' 
 #' @export
-nn_sequential <- function(... , name = NULL) {
-  module <- nn_module(
-    classname = ifelse(is.null(name), "nn_sequential", name),
-    initialize = function(...) {
-      modules <- rlang::list2(...)
-      for (i in seq_along(modules)) {
-        self$add_module(name = i - 1, module = modules[[i]])  
-      }
-    },
-    forward = function(input) {
-      for (module in private$modules_) {
-        input <- module(input)
-      }
-      input
+nn_sequential <- module <- nn_module(
+  classname = "nn_sequential",
+  initialize = function(...) {
+    modules <- rlang::list2(...)
+    for (i in seq_along(modules)) {
+      self$add_module(name = i - 1, module = modules[[i]])  
     }
-  )
-  module(...)
-}
+  },
+  forward = function(input) {
+    for (module in private$modules_) {
+      input <- module(input)
+    }
+    input
+  }
+)
 
 #' @export
 length.nn_sequential <- function(x) {

--- a/man/nn_sequential.Rd
+++ b/man/nn_sequential.Rd
@@ -4,12 +4,10 @@
 \alias{nn_sequential}
 \title{A sequential container}
 \usage{
-nn_sequential(..., name = NULL)
+nn_sequential(...)
 }
 \arguments{
 \item{...}{sequence of modules to be added}
-
-\item{name}{optional name for the generated module.}
 }
 \description{
 A sequential container.

--- a/tests/testthat/test-nn.R
+++ b/tests/testthat/test-nn.R
@@ -58,12 +58,14 @@ test_that("nn_sequential", {
   expect_equal(output$shape, c(1000, 1))
   expect_length(model$parameters, 4)
   
-  model <- nn_sequential(
-    name = "mynet",
+  my_sequential <- nn_module(inherit = nn_sequential, classname = "mynet")
+  
+  model <- my_sequential(
     nn_linear(10, 100),
     nn_relu(),
     nn_linear(100, 1)
   )
+  
   expect_s3_class(model, "mynet")
   expect_s3_class(model, "nn_module")
 })


### PR DESCRIPTION
This PR makes `nn_sequential` a bare `nn_module`. This allow inheriting from `nn_sequential` that might be useful in some scenarios. 

We no longer support the `name` argument, but its easy to modify the name via inheritance. See the modified test case.
Fix #674 