### PR TITLE
Fix rchk issues

### DIFF
--- a/src/script_module.cpp
+++ b/src/script_module.cpp
@@ -132,7 +132,7 @@ SEXP cpp_jit_script_module_find_constant (XPtrTorchScriptModule self,
   void* ret = lantern_ScriptModule_find_constant(self.get(), name.get());
   if (ret)
   {
-    return Rcpp::wrap(XPtrTorchIValue(ret));
+    return XPtrTorchIValue(ret);
   }
   else
   {

--- a/src/torch_types.cpp
+++ b/src/torch_types.cpp
@@ -49,7 +49,10 @@ XPtrTorchOptionalTensor::operator SEXP() const {
   }
   else 
   {
-    return XPtrTorchTensor(lantern_optional_tensor_value(this->get()));
+    auto ten = PROTECT(XPtrTorchTensor(lantern_optional_tensor_value(this->get())));
+    auto sxp = Rcpp::wrap(ten);
+    UNPROTECT(1);
+    return sxp;
   }
 }
 
@@ -356,7 +359,12 @@ XPtrTorchIValue::operator SEXP () const
     return Rcpp::wrap(XPtrTorchTensorList(lantern_IValue_TensorList(this->get())));
     
   case IValue_types::IValueTensorType:
-    return XPtrTorchTensor(lantern_IValue_Tensor(this->get()));
+  {
+    auto ten = PROTECT(XPtrTorchTensor(lantern_IValue_Tensor(this->get())));
+    auto sxp = Rcpp::wrap(ten);
+    UNPROTECT(1);
+    return sxp;
+  }
     
   case IValue_types::IValueTupleType:
     return Rcpp::wrap(XPtrTorchNamedTupleHelper(lantern_IValue_Tuple(this->get())));


### PR DESCRIPTION
Fix rchk issues. Most of them seems to be false positives, but we added protections to avoid them.
We wrapped intermediate values in `PROTECT` so rchk is fine with them being destroyed after the SEXP is returned.

Fix #703 
