### PR TITLE
Fix PDF manual

### DIFF
--- a/man/macros/teqn.Rd
+++ b/man/macros/teqn.Rd
@@ -1,1 +1,1 @@
-\newcommand{\teqn}{\if{html, text}{\eqn{#1}}\if{latex}{•}}
+\newcommand{\teqn}{\if{html, text}{\eqn{#1}}\if{latex}{ . }}


### PR DESCRIPTION
fix the PDF manual errors by using a different character when latex is present.
Fixes #704 