### PR TITLE
Fix `lantern` builds with CUDA

### DIFF
--- a/lantern/src/Contrib/SortVertices/sort_vert.cpp
+++ b/lantern/src/Contrib/SortVertices/sort_vert.cpp
@@ -25,12 +25,12 @@ SOFTWARE.
 */
 
 #define LANTERN_BUILD
-#include "sort_vert.h"
 
 #include <torch/torch.h>
 
 #include "../../utils.hpp"
 #include "lantern/lantern.h"
+#include "sort_vert.h"
 #include "utils.h"
 
 void sort_vertices_wrapper(int b, int n, int m, const float* vertices,


### PR DESCRIPTION
This fixes `lantern` builds with CUDA, specifically the following error:
```c++
[ 90%] Building CXX object CMakeFiles/lantern.dir/src/Contrib/SortVertices/sort_vert.cpp.o
In file included from /home/runner/work/torch/torch/lantern/src/Contrib/SortVertices/sort_vert.cpp:28:0:
/home/runner/work/torch/torch/lantern/src/Contrib/SortVertices/sort_vert.h:30:1: error: ‘at’ does not name a type; did you mean ‘auto’?
 at::Tensor sort_vertices(at::Tensor vertices, at::Tensor mask,
 ^~
 auto
make[2]: *** [CMakeFiles/lantern.dir/src/Contrib/SortVertices/sort_vert.cpp.o] Error 1
CMakeFiles/lantern.dir/build.make:558: recipe for target 'CMakeFiles/lantern.dir/src/Contrib/SortVertices/sort_vert.cpp.o' failed
```
as logged in https://github.com/mlverse/torch/runs/4833214597?check_suite_focus=true,

and tested in https://github.com/hsbadr/torch/runs/4833609413?check_suite_focus=true.