### PR TITLE
Disable warnings in `dir.create()` and remove `fs` dependency

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -233,7 +233,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install dependencies
         run: |
-          Rscript -e "options(repos=structure(c(CRAN='https://cloud.r-project.org/'))); install.packages(c('remotes', 'rcmdcheck', 'fs'))" -e "remotes::install_deps(dependencies = TRUE)"
+          Rscript -e "options(repos=structure(c(CRAN='https://cloud.r-project.org/'))); install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
       - name: Build lantern and get libtorch
         if: contains( github.event.pull_request.labels.*.name, 'lantern')
         run: |

--- a/R/install.R
+++ b/R/install.R
@@ -160,7 +160,7 @@ lantern_install_lib <- function(library_name, library_url,
   # if (length(header_files) > 0) {
   #   # also install the include files.
   #   include_dir <- file.path(system.file("", package = "torch"), "include/")
-  #   if (!dir.exists(include_dir)) dir.create(include_dir, recursive = TRUE)
+  #   dir.create(include_dir, showWarnings = FALSE, recursive = TRUE)
   #   file.copy(header_files, include_dir, recursive = TRUE)
   # }
 }

--- a/R/lantern_sync.R
+++ b/R/lantern_sync.R
@@ -1,7 +1,7 @@
 lantern_sync <- function(sync_lib = FALSE) {
   
   lib_dest <- "inst/"
-  suppressWarnings(dir.create(lib_dest))
+  dir.create(lib_dest, showWarnings = FALSE, recursive = TRUE)
   
   if (!all(tools::md5sum(dir("lantern/include/lantern/", full.names = TRUE)) %in%
     tools::md5sum(dir("inst/include/lantern/", full.names = TRUE)))) {
@@ -20,7 +20,7 @@ lantern_sync <- function(sync_lib = FALSE) {
       path <- list.files("lantern/build/Release/", full.names = TRUE)
     }
 
-    suppressWarnings(dir.create("inst/lib"))
+    dir.create("inst/lib", showWarnings = FALSE, recursive = TRUE)
 
     file.copy(
       path,

--- a/R/lantern_sync.R
+++ b/R/lantern_sync.R
@@ -1,15 +1,13 @@
 lantern_sync <- function(sync_lib = FALSE) {
-  
   lib_dest <- "inst/"
   dir.create(lib_dest, showWarnings = FALSE, recursive = TRUE)
-  
+
   if (!all(tools::md5sum(dir("lantern/include/lantern/", full.names = TRUE)) %in%
     tools::md5sum(dir("inst/include/lantern/", full.names = TRUE)))) {
     file.copy(dir("lantern/include/lantern/", full.names = TRUE), "inst/include/lantern/", overwrite = TRUE)
   }
 
   if (sync_lib) {
-    
     lib_src <- "lantern/build/liblantern"
 
     if (file.exists(paste0(lib_src, ".dylib"))) {

--- a/tools/buildlantern.R
+++ b/tools/buildlantern.R
@@ -1,16 +1,7 @@
-
-if (!require(fs, quietly = TRUE)) {
-  install.packages("fs")
-}
-
-if (!require(fs))
-  stop("fs was not correctly installed?")
-
 if (dir.exists("lantern")) {
   cat("Building lantern .... \n")
 
-  if (!fs::dir_exists("lantern/build"))
-    fs::dir_create("lantern/build")
+  dir.create("lantern/build", showWarnings = FALSE, recursive = TRUE)
 
   withr::with_dir("lantern/build", {
     system("cmake ..")


### PR DESCRIPTION
This PR disables warnings in `dir.create()` using `showWarnings = FALSE` argument to avoid using `suppressWarnings()` nor checking if the directory exists. It also simplifies `lantern` build and removes `fs` dependency by replacing `fs::dir_create()` with `dir.create()`. The `recursive = TRUE` argument makes `dir.create()` similar to the Unix command `mkdir -p`.