### PR TITLE
`torch_max` and `torch_min` when other has `length=2`

### DIFF
--- a/R/with-indices.R
+++ b/R/with-indices.R
@@ -50,15 +50,16 @@ torch_max_pool3d_with_indices_out <- function(out, indices, self, kernel_size, s
 
 torch_max <- function(self, dim, other, keepdim = FALSE) {
   o <- do.call(.torch_max, as.list(environment()))
-  if (length(o) == 2) {
+  if (is.list(o) && length(o) == 2) {
     o[[2]]$add_(1L, 1L)
   }
   o
 }
 
 torch_min <- function(self, dim, other, keepdim = FALSE) {
-  o <- do.call(.torch_min, as.list(environment()))
-  if (length(o) == 2) {
+  args <- as.list(environment())
+  o <- do.call(.torch_min, args)
+  if (is.list(o) && length(o) == 2) {
     o[[2]]$add_(1L, 1L)
   }
   o

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -244,6 +244,11 @@ test_that("max and min", {
     x$min(dim = 1, other = 2),
     class = "value_error"
   )
+  
+  
+  x <- torch_tensor(c(1,2))
+  expect_equal_to_r(x$min(other = c(2,1)), c(1,1))
+  expect_equal_to_r(x$max(other = c(2,1)), c(2,2))
 })
 
 test_that("element_size works", {

--- a/tests/testthat/test-with-indices.R
+++ b/tests/testthat/test-with-indices.R
@@ -3,6 +3,11 @@ test_that("max with indices", {
   m <- torch_max(x, dim = 1)
 
   expect_equal_to_r(m[[2]]$to(dtype = torch_int()), 4)
+  
+  expect_equal_to_r(
+    torch_max(c(2,1), other = c(1,2)),
+    c(2,2)
+  )
 })
 
 test_that("min with indices", {
@@ -10,6 +15,11 @@ test_that("min with indices", {
   m <- torch_min(x, dim = 1)
 
   expect_equal_to_r(m[[2]]$to(dtype = torch_int()), 1)
+  
+  expect_equal_to_r(
+    torch_min(c(2,1), other = c(1,2)),
+    c(1,1)
+  )
 })
 
 test_that("argsort", {


### PR DESCRIPTION
Fix #712 