### PR TITLE
Make dataloaders slightly faster by using a custom transpose function.

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -11409,6 +11409,10 @@ cpp_torch_namespace__store_main_thread_id <- function() {
     invisible(.Call('_torch_cpp_torch_namespace__store_main_thread_id', PACKAGE = 'torchpkg'))
 }
 
+transpose2 <- function(x) {
+    .Call('_torch_transpose2', PACKAGE = 'torchpkg', x)
+}
+
 cpp_torch_variable_list <- function(x) {
     .Call('_torch_cpp_torch_variable_list', PACKAGE = 'torchpkg', x)
 }

--- a/R/utils-data-collate.R
+++ b/R/utils-data-collate.R
@@ -21,14 +21,7 @@ utils_data_default_collate <- function(batch) {
   } else if (is.character(elem) && length(elem) == 1) {
     return(unlist(batch))
   } else if (is.list(elem)) {
-
-    # preserves the element names
-    named_seq <- seq_along(elem)
-    names(named_seq) <- names(elem)
-
-    lapply(named_seq, function(i) {
-      utils_data_default_collate(lapply(batch, function(x) x[[i]]))
-    })
+    lapply(transpose2(batch), utils_data_default_collate)
   } else {
     value_error("Can't collate data of class: '{class(data)}'")
   }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -37160,6 +37160,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// transpose2
+Rcpp::List transpose2(Rcpp::List x);
+RcppExport SEXP _torch_transpose2(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::List >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(transpose2(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_torch_variable_list
 Rcpp::XPtr<XPtrTorchvariable_list> cpp_torch_variable_list(const Rcpp::List& x);
 RcppExport SEXP _torch_cpp_torch_variable_list(SEXP xSEXP) {
@@ -40071,6 +40082,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_to_index_tensor", (DL_FUNC) &_torch_to_index_tensor, 1},
     {"_torch_cpp_torch_namespace__use_cudnn_rnn_flatten_weight", (DL_FUNC) &_torch_cpp_torch_namespace__use_cudnn_rnn_flatten_weight, 0},
     {"_torch_cpp_torch_namespace__store_main_thread_id", (DL_FUNC) &_torch_cpp_torch_namespace__store_main_thread_id, 0},
+    {"_torch_transpose2", (DL_FUNC) &_torch_transpose2, 1},
     {"_torch_cpp_torch_variable_list", (DL_FUNC) &_torch_cpp_torch_variable_list, 1},
     {"_torch_cpp_variable_list_to_r_list", (DL_FUNC) &_torch_cpp_variable_list_to_r_list, 1},
     {"_torch_set_xptr_address", (DL_FUNC) &_torch_set_xptr_address, 2},

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -61,3 +61,32 @@ std::thread::id main_thread_id() noexcept {
 
   return tid;
 }
+
+// [[Rcpp::export]]
+Rcpp::List transpose2 (Rcpp::List x) {
+  auto templ = Rcpp::as<Rcpp::List>(x[0]);
+  auto num_elements = templ.length();
+  
+  auto size = x.length();
+  std::vector<Rcpp::List> out;
+  
+  for (auto i = 0; i < num_elements; i++) {
+    out.push_back(Rcpp::List(size));
+  }
+  
+  for (size_t j = 0; j < size; j++) {
+    auto el = Rcpp::as<Rcpp::List>(x[j]);
+    for (auto i = 0; i < num_elements; i++) {
+      out[i][j] = el[i];
+    }
+  }
+  
+  Rcpp::List ret;
+  for (auto i = 0; i < num_elements; i++) {
+    ret.push_back(out[i]);
+  }
+  
+  ret.names() = templ.names();
+  
+  return ret;
+}


### PR DESCRIPTION
The new function used for transposing the batches when 'collating' in the dataloader is ~6x. This makes dataloader in general slightly faster ~3/4% in a typical example.

``` r
library(purrr)
library(collapse)
#> Warning: package 'collapse' was built under R version 4.1.2
#> collapse 1.7.5, see ?`collapse-package` or ?`collapse-documentation`
#> 
#> Attaching package: 'collapse'
#> The following object is masked from 'package:stats':
#> 
#>     D

batch <- purrr::rerun(1000, x = array(1, c(32,32,3)), y = runif(5))
transpose2 <- torch:::transpose2

bench::mark(
  old = lapply(setNames(1:2, names(batch[[1]])), function(i) {
    lapply(batch, function(x) x[[i]])
  }),
  new = transpose2(batch),
  purrr = transpose(batch),
  base = do.call(Map, c(f = list, batch)),
  collapase = t_list(batch)
)
#> # A tibble: 5 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old           928µs   1.02ms      966.      94KB     51.8
#> 2 new           123µs 139.42µs     6958.    18.2KB     44.3
#> 3 purrr         205µs 226.97µs     4301.    18.1KB     52.4
#> 4 base          822µs 927.39µs     1034.    70.8KB     50.0
#> 5 collapase     291µs 331.25µs     2941.    40.9KB     21.3
```

<sup>Created on 2022-02-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>