### PR TITLE
Cpp version of torch tensor

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -11265,6 +11265,10 @@ torch_tensor_cpp <- function(x, dtype, device, requires_grad, pin_memory) {
     .Call('_torch_torch_tensor_cpp', PACKAGE = 'torchpkg', x, dtype, device, requires_grad, pin_memory)
 }
 
+list_of_tensors <- function(x) {
+    .Call('_torch_list_of_tensors', PACKAGE = 'torchpkg', x)
+}
+
 cpp_as_array <- function(x) {
     .Call('_torch_cpp_as_array', PACKAGE = 'torchpkg', x)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -11261,8 +11261,8 @@ cpp_torch_tensor_dtype <- function(x) {
     .Call('_torch_cpp_torch_tensor_dtype', PACKAGE = 'torchpkg', x)
 }
 
-cpp_torch_tensor <- function(x, dim, options, requires_grad, is_integer64) {
-    .Call('_torch_cpp_torch_tensor', PACKAGE = 'torchpkg', x, dim, options, requires_grad, is_integer64)
+torch_tensor_cpp <- function(x, dtype, device, requires_grad, pin_memory) {
+    .Call('_torch_torch_tensor_cpp', PACKAGE = 'torchpkg', x, dtype, device, requires_grad, pin_memory)
 }
 
 cpp_as_array <- function(x) {

--- a/R/install.R
+++ b/R/install.R
@@ -1,4 +1,4 @@
-branch <- "libtorch1.10.2"
+branch <- "main"
 
 install_config <- list(
   "1.10.2" = list(

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -9,36 +9,7 @@ Tensor <- R7Class(
         return(ptr)
       }
 
-      # infer dtype from data
-      if (is.null(dtype)) {
-        if (is.integer(data)) {
-          dtype <- torch_long()
-        } else if (bit64::is.integer64(data)) {
-          dtype <- torch_long()
-        } else if (is.double(data)) {
-          dtype <- torch_float() # default to float
-        } else if (is.logical(data)) {
-          dtype <- torch_bool()
-        }
-      }
-
-      options <- torch_tensor_options(
-        dtype = dtype, device = device,
-        pinned_memory = pin_memory
-      )
-
-
-      dimension <- dim(data)
-
-      if (is.null(dimension)) {
-        dimension <- length(data)
-      }
-
-
-      cpp_torch_tensor(
-        data, rev(dimension), options,
-        requires_grad, inherits(data, "integer64")
-      )
+     torch_tensor_cpp(data, dtype, device, requires_grad, pin_memory)
     },
     print = function(n = 30) {
       cat("torch_tensor\n")

--- a/R/utils-data-collate.R
+++ b/R/utils-data-collate.R
@@ -1,13 +1,20 @@
+is_tensor_like <- function(x) {
+  # we want arrays, matrix's and vectors (lenght > 1) to be converted to
+  # tensors. this is only different from torch because there are native
+  # scalar types in Python
+  has_tensor_like_types <- is.atomic(x) && (!is.character(x))
+  has_tensor_like_types && (length(x) > 1 || is.array(x) || is.matrix(x))
+}
+
 utils_data_default_collate <- function(batch) {
   elem <- batch[[1]]
   if (is_torch_tensor(elem)) {
     return(torch_stack(batch, dim = 1))
-  } else if ((!is.character(elem) && !is.list(elem)) && is.atomic(elem) &&
-    (is.array(elem) || is.matrix(elem) || length(elem) > 1)) {
+  } else if (is_tensor_like(elem)) {
     # we want arrays, matrix's and vectors (lenght > 1) to be converted to
     # tensors. this is only different fromr torch because there's differentiation
     # between lenght 1 vectors and scalars.
-    return(utils_data_default_collate(list_of_tensors(batch)))
+    return(torch_stack(list_of_tensors(batch), dim = 1))
   } else if (is.integer(elem) && length(elem) == 1) {
     k <- unlist(batch)
     return(torch_tensor(k, dtype = torch_long()))

--- a/R/utils-data-collate.R
+++ b/R/utils-data-collate.R
@@ -7,11 +7,7 @@ utils_data_default_collate <- function(batch) {
     # we want arrays, matrix's and vectors (lenght > 1) to be converted to
     # tensors. this is only different fromr torch because there's differentiation
     # between lenght 1 vectors and scalars.
-    return(
-      utils_data_default_collate(
-        lapply(batch, function(x) torch_tensor(x))
-      )
-    )
+    return(utils_data_default_collate(list_of_tensors(batch)))
   } else if (is.integer(elem) && length(elem) == 1) {
     k <- unlist(batch)
     return(torch_tensor(k, dtype = torch_long()))

--- a/inst/include/lantern/lantern.h
+++ b/inst/include/lantern/lantern.h
@@ -184,8 +184,6 @@ LANTERN_OPTIONAL_DECLS(string_view)
   HOST_API const char * lantern_Device_type(void *device) {LANTERN_CHECK_LOADED const char * ret = _lantern_Device_type(device); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Device_index)(void *device);
   HOST_API int64_t lantern_Device_index(void *device) {LANTERN_CHECK_LOADED int64_t ret = _lantern_Device_index(device); LANTERN_HOST_HANDLER return ret;}
-  LANTERN_API void *(LANTERN_PTR _lantern_from_blob)(void *data, int64_t *sizes, size_t sizes_size, void *options);
-  HOST_API void * lantern_from_blob(void *data, int64_t *sizes, size_t sizes_size, void *options) {LANTERN_CHECK_LOADED void * ret = _lantern_from_blob(data, sizes, sizes_size, options); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API const char *(LANTERN_PTR _lantern_Tensor_StreamInsertion)(void *x);
   HOST_API const char * lantern_Tensor_StreamInsertion(void *x) {LANTERN_CHECK_LOADED const char * ret = _lantern_Tensor_StreamInsertion(x); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void *(LANTERN_PTR _lantern_TensorOptions)();
@@ -2261,6 +2259,16 @@ HOST_API void set_delete_lambda_fun (void (*fun)(void*))
   LANTERN_CHECK_LOADED
   _set_delete_lambda_fun(fun);
   LANTERN_HOST_HANDLER;
+}
+
+LANTERN_API void* (LANTERN_PTR _lantern_from_blob) (void* data, int64_t *sizes, size_t sizes_size,
+                          int64_t* strides, size_t strides_size, void* options);
+HOST_API void* lantern_from_blob(void* data, int64_t *sizes, size_t sizes_size,
+                          int64_t* strides, size_t strides_size, void* options) { 
+  LANTERN_CHECK_LOADED
+  void* ret = _lantern_from_blob(data, sizes, sizes_size, strides, strides_size, options);
+  LANTERN_HOST_HANDLER;
+  return ret;
 }
 
   /* Autogen Headers -- Start */

--- a/inst/include/utils.h
+++ b/inst/include/utils.h
@@ -95,5 +95,10 @@ std::array<type, n> std_vector_to_std_array(std::vector<type> x) {
 
 XPtrTorchTensor cpp_tensor_undefined();
 XPtrTorchTensor to_index_tensor(XPtrTorchTensor t);
+torch::Tensor torch_tensor_cpp (SEXP x, 
+                                Rcpp::Nullable<torch::Dtype> dtype = R_NilValue,
+                                Rcpp::Nullable<torch::Device> device = R_NilValue,
+                                bool requires_grad = false,
+                                bool pin_memory = false);
 
 std::thread::id main_thread_id() noexcept;

--- a/lantern/include/lantern/lantern.h
+++ b/lantern/include/lantern/lantern.h
@@ -184,8 +184,6 @@ LANTERN_OPTIONAL_DECLS(string_view)
   HOST_API const char * lantern_Device_type(void *device) {LANTERN_CHECK_LOADED const char * ret = _lantern_Device_type(device); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API int64_t(LANTERN_PTR _lantern_Device_index)(void *device);
   HOST_API int64_t lantern_Device_index(void *device) {LANTERN_CHECK_LOADED int64_t ret = _lantern_Device_index(device); LANTERN_HOST_HANDLER return ret;}
-  LANTERN_API void *(LANTERN_PTR _lantern_from_blob)(void *data, int64_t *sizes, size_t sizes_size, void *options);
-  HOST_API void * lantern_from_blob(void *data, int64_t *sizes, size_t sizes_size, void *options) {LANTERN_CHECK_LOADED void * ret = _lantern_from_blob(data, sizes, sizes_size, options); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API const char *(LANTERN_PTR _lantern_Tensor_StreamInsertion)(void *x);
   HOST_API const char * lantern_Tensor_StreamInsertion(void *x) {LANTERN_CHECK_LOADED const char * ret = _lantern_Tensor_StreamInsertion(x); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void *(LANTERN_PTR _lantern_TensorOptions)();
@@ -2261,6 +2259,16 @@ HOST_API void set_delete_lambda_fun (void (*fun)(void*))
   LANTERN_CHECK_LOADED
   _set_delete_lambda_fun(fun);
   LANTERN_HOST_HANDLER;
+}
+
+LANTERN_API void* (LANTERN_PTR _lantern_from_blob) (void* data, int64_t *sizes, size_t sizes_size,
+                          int64_t* strides, size_t strides_size, void* options);
+HOST_API void* lantern_from_blob(void* data, int64_t *sizes, size_t sizes_size,
+                          int64_t* strides, size_t strides_size, void* options) { 
+  LANTERN_CHECK_LOADED
+  void* ret = _lantern_from_blob(data, sizes, sizes_size, strides, strides_size, options);
+  LANTERN_HOST_HANDLER;
+  return ret;
 }
 
   /* Autogen Headers -- Start */

--- a/lantern/src/Tensor.cpp
+++ b/lantern/src/Tensor.cpp
@@ -7,12 +7,13 @@
 #include "lantern/lantern.h"
 #include "utils.hpp"
 
-void *_lantern_from_blob(void *data, int64_t *sizes, size_t sizes_size,
-                         void *options) {
+void* _lantern_from_blob(void* data, int64_t *sizes, size_t sizes_size,
+                          int64_t* strides, size_t strides_size, void* options) {
   LANTERN_FUNCTION_START
-  return make_raw::Tensor(
-      torch::from_blob(data, std::vector<int64_t>(sizes, sizes + sizes_size),
-                       from_raw::TensorOptions(options)));
+  return make_raw::Tensor(torch::from_blob(
+      data, std::vector<int64_t>(sizes, sizes + sizes_size),
+      std::vector<int64_t>(strides, strides + strides_size),
+      from_raw::TensorOptions(options)));
   LANTERN_FUNCTION_END
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -36752,6 +36752,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// list_of_tensors
+Rcpp::List list_of_tensors(Rcpp::List x);
+RcppExport SEXP _torch_list_of_tensors(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::List >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(list_of_tensors(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_as_array
 Rcpp::List cpp_as_array(Rcpp::XPtr<torch::Tensor> x);
 RcppExport SEXP _torch_cpp_as_array(SEXP xSEXP) {
@@ -40046,6 +40057,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_torch_tensor_print", (DL_FUNC) &_torch_cpp_torch_tensor_print, 2},
     {"_torch_cpp_torch_tensor_dtype", (DL_FUNC) &_torch_cpp_torch_tensor_dtype, 1},
     {"_torch_torch_tensor_cpp", (DL_FUNC) &_torch_torch_tensor_cpp, 5},
+    {"_torch_list_of_tensors", (DL_FUNC) &_torch_list_of_tensors, 1},
     {"_torch_cpp_as_array", (DL_FUNC) &_torch_cpp_as_array, 1},
     {"_torch_cpp_tensor_element_size", (DL_FUNC) &_torch_cpp_tensor_element_size, 1},
     {"_torch_cpp_tensor_dim", (DL_FUNC) &_torch_cpp_tensor_dim, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -36737,18 +36737,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// cpp_torch_tensor
-torch::Tensor cpp_torch_tensor(SEXP x, std::vector<std::int64_t> dim, torch::TensorOptions options, bool requires_grad, bool is_integer64);
-RcppExport SEXP _torch_cpp_torch_tensor(SEXP xSEXP, SEXP dimSEXP, SEXP optionsSEXP, SEXP requires_gradSEXP, SEXP is_integer64SEXP) {
+// torch_tensor_cpp
+torch::Tensor torch_tensor_cpp(SEXP x, Rcpp::Nullable<torch::Dtype> dtype, Rcpp::Nullable<torch::Device> device, bool requires_grad, bool pin_memory);
+RcppExport SEXP _torch_torch_tensor_cpp(SEXP xSEXP, SEXP dtypeSEXP, SEXP deviceSEXP, SEXP requires_gradSEXP, SEXP pin_memorySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::vector<std::int64_t> >::type dim(dimSEXP);
-    Rcpp::traits::input_parameter< torch::TensorOptions >::type options(optionsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<torch::Dtype> >::type dtype(dtypeSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<torch::Device> >::type device(deviceSEXP);
     Rcpp::traits::input_parameter< bool >::type requires_grad(requires_gradSEXP);
-    Rcpp::traits::input_parameter< bool >::type is_integer64(is_integer64SEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_torch_tensor(x, dim, options, requires_grad, is_integer64));
+    Rcpp::traits::input_parameter< bool >::type pin_memory(pin_memorySEXP);
+    rcpp_result_gen = Rcpp::wrap(torch_tensor_cpp(x, dtype, device, requires_grad, pin_memory));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -40045,7 +40045,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_Storage_data_ptr", (DL_FUNC) &_torch_cpp_Storage_data_ptr, 1},
     {"_torch_cpp_torch_tensor_print", (DL_FUNC) &_torch_cpp_torch_tensor_print, 2},
     {"_torch_cpp_torch_tensor_dtype", (DL_FUNC) &_torch_cpp_torch_tensor_dtype, 1},
-    {"_torch_cpp_torch_tensor", (DL_FUNC) &_torch_cpp_torch_tensor, 5},
+    {"_torch_torch_tensor_cpp", (DL_FUNC) &_torch_torch_tensor_cpp, 5},
     {"_torch_cpp_as_array", (DL_FUNC) &_torch_cpp_as_array, 1},
     {"_torch_cpp_tensor_element_size", (DL_FUNC) &_torch_cpp_tensor_element_size, 1},
     {"_torch_cpp_tensor_dim", (DL_FUNC) &_torch_cpp_tensor_dim, 1},

--- a/src/indexing.cpp
+++ b/src/indexing.cpp
@@ -121,10 +121,6 @@ void index_append_slice(XPtrTorchTensorIndex& index, SEXP slice) {
   lantern_TensorIndex_append_slice(index.get(), l.get());
 }
 
-XPtrTorchTensor cpp_torch_tensor(SEXP x, std::vector<std::int64_t> dim,
-                                 XPtrTorchTensorOptions options,
-                                 bool requires_grad, bool is_integer64);
-
 void index_append_integer_vector(XPtrTorchTensorIndex& index, SEXP slice) {
   Rcpp::NumericVector v(
       LENGTH(slice));  // tmp variable v to avoid changing slice object
@@ -140,12 +136,7 @@ void index_append_integer_vector(XPtrTorchTensorIndex& index, SEXP slice) {
   }
 
   // Create the integer Tensor
-  XPtrTorchTensorOptions options = lantern_TensorOptions();
-  options = lantern_TensorOptions_dtype(
-      options.get(), XPtrTorchDtype(lantern_Dtype_int64()).get());
-  std::vector<int64_t> dim = {LENGTH(slice)};
-
-  XPtrTorchTensor tensor = cpp_torch_tensor(v, dim, options, false, false);
+  auto tensor = torch_tensor_cpp(v, torch::Dtype(lantern_Dtype_int64()));
 
   lantern_TensorIndex_append_tensor(index.get(), tensor.get());
 }
@@ -154,12 +145,7 @@ void index_append_bool_vector(XPtrTorchTensorIndex& index, SEXP slice) {
   Rcpp::LogicalVector v = slice;
 
   // Create the integer Tensor
-  XPtrTorchTensorOptions options = lantern_TensorOptions();
-  options = lantern_TensorOptions_dtype(
-      options.get(), XPtrTorchDtype(lantern_Dtype_bool()).get());
-  std::vector<int64_t> dim = {LENGTH(slice)};
-
-  XPtrTorchTensor tensor = cpp_torch_tensor(v, dim, options, false, false);
+  auto tensor = torch_tensor_cpp(v, torch::Dtype(lantern_Dtype_bool()));
 
   lantern_TensorIndex_append_tensor(index.get(), tensor.get());
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -54,76 +54,82 @@ Rcpp::XPtr<XPtrTorchDtype> cpp_torch_tensor_dtype(torch::Tensor x) {
   return make_xptr<XPtrTorchDtype>(out);
 }
 
-// equivalent to (n-1):0 in R
-std::vector<int64_t> revert_int_seq(int n) {
-  std::vector<int64_t> l(n);
-  std::iota(l.begin(), l.end(), 0);
-  std::reverse(l.begin(), l.end());
-  return l;
-};
-
-template <int RTYPE>
-torch::Tensor tensor_from_r_array(const SEXP x, std::vector<int64_t> dim,
-                                  std::string dtype) {
-  Rcpp::Vector<RTYPE> vec(x);
-
-  torch::TensorOptions options = lantern_TensorOptions();
-
-  if (dtype == "double") {
-    options = lantern_TensorOptions_dtype(
-        options.get(), XPtrTorchDtype(lantern_Dtype_float64()).get());
-  } else if (dtype == "int") {
-    options = lantern_TensorOptions_dtype(
-        options.get(), XPtrTorchDtype(lantern_Dtype_int32()).get());
-  } else if (dtype == "int64") {
-    options = lantern_TensorOptions_dtype(
-        options.get(), XPtrTorchDtype(lantern_Dtype_int64()).get());
+std::vector<int64_t> stride_from_dim (std::vector<int64_t> x) {
+  auto ret = std::vector<int64_t>(x.size());
+  ret[0] = 1;
+  for (int i = 1; i < x.size(); i++) {
+    ret[i] = ret[i-1]*x[i-1];
   }
+  return ret;
+}
 
-  options = lantern_TensorOptions_device(
-      options.get(), XPtrTorchDevice(lantern_Device("cpu", 0, false)).get());
-
-  torch::Tensor tensor =
-      lantern_from_blob(vec.begin(), &dim[0], dim.size(), options.get());
-
+// [[Rcpp::export]]
+torch::Tensor torch_tensor_cpp (SEXP x, 
+                                Rcpp::Nullable<torch::Dtype> dtype,
+                                Rcpp::Nullable<torch::Device> device,
+                                bool requires_grad,
+                                bool pin_memory) {
+  
+  torch::Dtype cdtype;
+  torch::Dtype final_type;
+  
+  switch (TYPEOF(x)) {
+  case INTSXP: {
+    cdtype = lantern_Dtype_int32();
+    final_type = dtype.isNull() ? torch::Dtype(lantern_Dtype_int64()) : Rcpp::as<torch::Dtype>(dtype);
+    break;
+  }
+  case REALSXP: {
+    auto is_int64 = Rf_inherits(x, "integer64");
+    cdtype = is_int64 ? lantern_Dtype_int64() : lantern_Dtype_float64();
+    if (dtype.isNull()) {
+      final_type = is_int64 ? lantern_Dtype_int64() : lantern_Dtype_float32();
+    } else {
+      final_type = Rcpp::as<torch::Dtype>(dtype);
+    }
+    break;
+  }
+  case LGLSXP: {
+    cdtype = lantern_Dtype_int32();
+    final_type = dtype.isNull() ? torch::Dtype(lantern_Dtype_bool()) : Rcpp::as<torch::Dtype>(dtype);
+    break;
+  }
+  default: {
+    Rcpp::stop("R type not handled");
+  }
+  }
+  
+  // We now create the first tensor wrapping the R object. Here we use `cdtype`
+  // For example when the SEXP is a logical vector, it actually store values as
+  // int32 so we first create a int32 tensor and then cast to a boolean.
+  torch::TensorOptions options = lantern_TensorOptions();
+  options = lantern_TensorOptions_dtype(options.get(), cdtype.get());
+  
+  auto d = Rcpp::as<Rcpp::Nullable<std::vector<int64_t>>>(Rf_getAttrib(x, R_DimSymbol));
+  auto dim = d.isNotNull() ? Rcpp::as<std::vector<int64_t>>(d) : std::vector<int64_t>(1, LENGTH(x));
+  auto strides = stride_from_dim(dim);
+  
+  torch::Tensor tensor = lantern_from_blob(DATAPTR(x), 
+                                           &dim[0], dim.size(), 
+                                           &strides[0], strides.size(), 
+                                           options.get());
+  
   if (dim.size() == 1) {
     // if we have a 1-dim vector contigous doesn't trigger a copy, and
     // would be unexpected.
     tensor = lantern_Tensor_clone(tensor.get());
   }
-
-  auto reverse_dim = revert_int_seq(dim.size());
-  tensor = lantern_Tensor_permute(
-      tensor.get(),
-      XPtrTorchvector_int64_t(
-          lantern_vector_int64_t(&reverse_dim[0], reverse_dim.size()))
-          .get());
   tensor = lantern_Tensor_contiguous(tensor.get());
-
-  return tensor;
-};
-
-// [[Rcpp::export]]
-torch::Tensor cpp_torch_tensor(SEXP x, std::vector<std::int64_t> dim,
-                               torch::TensorOptions options, bool requires_grad,
-                               bool is_integer64) {
-  torch::Tensor tensor;
-
-  if (TYPEOF(x) == INTSXP) {
-    tensor = tensor_from_r_array<INTSXP>(x, dim, "int");
-  } else if (TYPEOF(x) == REALSXP && !is_integer64) {
-    tensor = tensor_from_r_array<REALSXP>(x, dim, "double");
-  } else if (TYPEOF(x) == REALSXP && is_integer64) {
-    tensor = tensor_from_r_array<REALSXP>(x, dim, "int64");
-  } else if (TYPEOF(x) == LGLSXP) {
-    tensor = tensor_from_r_array<LGLSXP>(x, dim, "int");
-  } else {
-    Rcpp::stop("R type not handled");
-  };
-
+  
+  // We will now cast to the final options.
+  options = lantern_TensorOptions_dtype(options.get(), final_type.get());
+  if (device.isNotNull()) {
+    options = lantern_TensorOptions_device(options.get(), Rcpp::as<torch::Device>(device).get());
+  }
+  options = lantern_TensorOptions_pinned_memory(options.get(), pin_memory);
   tensor = lantern_Tensor_to(tensor.get(), options.get());
   tensor = lantern_Tensor_set_requires_grad(tensor.get(), requires_grad);
-
+  
   return tensor;
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -133,6 +133,19 @@ torch::Tensor torch_tensor_cpp (SEXP x,
   return tensor;
 }
 
+
+// A faster version of `lapply(x, torch_tensor)`.
+// [[Rcpp::export]]
+Rcpp::List list_of_tensors (Rcpp::List x) {
+  int n = x.size();
+  Rcpp::List out(n);
+  for (int i = 0; i < n; i++) {
+    SEXP v = x[i];
+    out[i] = Rcpp::wrap(torch_tensor_cpp(v));
+  }
+  return out;
+}
+
 Rcpp::IntegerVector tensor_dimensions(torch::Tensor x) {
   int64_t ndim = lantern_Tensor_ndimension(x.get());
   Rcpp::IntegerVector dimensions(ndim);

--- a/src/torch_api.cpp
+++ b/src/torch_api.cpp
@@ -128,10 +128,7 @@ XPtrTorchTensor from_sexp_tensor(SEXP x) {
 
   // TODO: it would be nice to make it all C++
   if (Rf_isVectorAtomic(x)) {
-    Rcpp::Environment torch_pkg = Rcpp::Environment("package:torch");
-    Rcpp::Function f = torch_pkg["torch_tensor"];
-    return XPtrTorchTensor(
-        Rcpp::as<Rcpp::XPtr<XPtrTorchTensor>>(f(x))->get_shared());
+    return torch_tensor_cpp(x);
   }
 
   Rcpp::stop("Expected a torch_tensor.");


### PR DESCRIPTION
Fix #470 

We also added a function `list_of_tensors` that casts a list of tensor_like objects to tensors, a little faster than `lapply(batch, torch_tensor)`.

With this PR we slightly improve performance of dataloaders. For instance:

New code:

``` r
data <- torchvision::cifar100_dataset(root = "./bench/", download = TRUE)
dl <- torch::dataloader(data, batch_size = 32)

bench::system_time({
  coro::loop(for (b in dl) {
    x <- b
  })
})
#> process    real 
#>   8.03s   8.08s
```

<sup>Created on 2022-02-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Old code:

``` r
data <- torchvision::cifar100_dataset(root = "./bench/", download = TRUE)
dl <- torch::dataloader(data, batch_size = 32)

bench::system_time({
  coro::loop(for (b in dl) {
    x <- b
  })
})
#> process    real 
#>   11.5s   11.5s
```

<sup>Created on 2022-02-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>