### PR TITLE
On Windows query cuda_version from nvcc instead from version.txt

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -239,11 +239,10 @@ install_type_windows <- function(version) {
   cuda_version <- NULL
   cuda_path <- Sys.getenv("CUDA_PATH")
 
-  if (nzchar(cuda_path)) {
-    versions_file <- file.path(cuda_path, "version.txt")
-    if (file.exists(versions_file)) {
-      cuda_version <- gsub("CUDA Version |\\.[0-9]+$", "", readLines(versions_file))
-    }
+  # Query nvcc from cuda in cuda_path.
+  if (nzchar(cuda_path) && is.null(cuda_version)) {
+    nvcc_path <- file.path(cuda_path, "bin", "nvcc.exe")
+    cuda_version <- nvcc_version_from_path(nvcc_path)
   }
 
   if (is.null(cuda_version)) {


### PR DESCRIPTION
Hi, this PR solves the issue #797 on windows that the `version.txt` file is not present anymore from CUDA 11 onwards. It now uses the same function as already is used on Linux to query the `cuda_version` from the nvcc command instead of parsing `version.txt`. However, instead of the using environment variable `CUDA_HOME`  (which is used on linux) `CUDA_PATH` is used and it refers to the nvcc executable.

Testing it on my windows machine with CUDA 11.1 resulted in a successful installation of `torch` for gpu. 
