### PR TITLE
Correct typo in code argument.

### DIFF
--- a/R/autograd.R
+++ b/R/autograd.R
@@ -14,7 +14,7 @@ NULL
 #' This mode should be enabled only for debugging as the different tests
 #' will slow down your program execution.
 #'
-#' @param code Cod that will be execued in the detect anomaly context.
+#' @param code Code that will be executed in the detect anomaly context.
 #'
 #' @examples
 #' x <- torch_randn(2, requires_grad = TRUE)

--- a/R/cuda.R
+++ b/R/cuda.R
@@ -152,12 +152,12 @@ print.cuda_memory_stats <- function(x, ...) {
 }
 
 #' Returns the CUDA runtime version
-#' 
+#'
 #' @export
 cuda_runtime_version <- function() {
   v <- cpp_cuda_get_runtime_version()
-  major <- trunc(v/1000)
-  minor <- trunc((v - major*1000)/10)
-  patch <- v - major*1000 - minor*10
+  major <- trunc(v / 1000)
+  minor <- trunc((v - major * 1000) / 10)
+  patch <- v - major * 1000 - minor * 10
   numeric_version(paste(major, minor, patch, sep = "."))
 }

--- a/R/install.R
+++ b/R/install.R
@@ -238,7 +238,7 @@ lantern_install_libs <- function(version, type, install_path, install_config) {
 install_type_windows <- function(version) {
   cuda_version <- NULL
   cuda_path <- Sys.getenv("CUDA_PATH")
-  
+
   if (nzchar(cuda_path)) {
     versions_file <- file.path(cuda_path, "version.txt")
     if (file.exists(versions_file)) {

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -14,7 +14,7 @@ Tensor <- R7Class(
     print = function(n = 30) {
       cat("torch_tensor\n")
       if (is_undefined_tensor(self) || !is_meta_device(self$device)) {
-        cpp_torch_tensor_print(self$ptr, n)  
+        cpp_torch_tensor_print(self$ptr, n)
       } else {
         cat("...\n")
         dtype <- as.character(self$dtype)

--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -45,7 +45,7 @@ get_init <- function(x) {
 #' that will be used instead of `.getitem` when getting a batch of observations within
 #' the dataloader. `.getbatch` must work for batches of size larger or equal to 1. For more
 #' on this see the the `vignette("loading-data")`.
-#' 
+#'
 #' @note
 #' [dataloader()]  by default constructs a index
 #' sampler that yields integral indices.  To make it work with a map-style

--- a/lantern/src/Cuda.cpp
+++ b/lantern/src/Cuda.cpp
@@ -186,17 +186,17 @@ void* _lantern_cuda_device_stats(int64_t device) {
       "`cuda_device_stats` is only supported on CUDA runtimes.");
 #endif
   LANTERN_FUNCTION_END
-} 
+}
 
-int _lantern_cuda_get_runtime_version () {
+int _lantern_cuda_get_runtime_version() {
   LANTERN_FUNCTION_START
 #ifdef __NVCC__
   int runtimeVersion;
-  cudaRuntimeGetVersion(&runtimeVersion);    
+  cudaRuntimeGetVersion(&runtimeVersion);
   return runtimeVersion;
 #else
   throw std::runtime_error(
-          "`cuda_device_stats` is only supported on CUDA runtimes.");
+      "`cuda_device_stats` is only supported on CUDA runtimes.");
 #endif
   LANTERN_FUNCTION_END
 }

--- a/src/cuda.cpp
+++ b/src/cuda.cpp
@@ -26,6 +26,6 @@ torch::vector::int64_t cpp_cuda_memory_stats(int64_t device) {
 }
 
 // [[Rcpp::export]]
-int cpp_cuda_get_runtime_version () {
+int cpp_cuda_get_runtime_version() {
   return lantern_cuda_get_runtime_version();
 }


### PR DESCRIPTION
Correcting a small typo in `autograd` R script file.