### PR TITLE
Allow not implementing the `initialize` method

### DIFF
--- a/R/nn.R
+++ b/R/nn.R
@@ -17,6 +17,7 @@ nn_Module <- R6::R6Class(
   lock_objects = FALSE,
   public = list(
     training = TRUE,
+    initialize = function() {},
     forward = function(...) {
       not_implemented_error("Forward method is not implemented")
     },

--- a/tests/testthat/test-nn.R
+++ b/tests/testthat/test-nn.R
@@ -625,3 +625,8 @@ test_that("classes are inherited correctly", {
   n2 <- nn2(10, 10)
   expect_equal(class(n2), c("goodbye", "hello", "nn_linear", "nn_module"))
 })
+
+test_that("empty initializer", {
+  model <- nn_module(forward = function(input) input)
+  expect_equal_to_r(model()(torch_tensor(1)), 1)
+})


### PR DESCRIPTION
In this case a function that does nothing is used.
Fix #802 