### PR TITLE
terminate called without an active exception

### DIFF
--- a/inst/include/utils.h
+++ b/inst/include/utils.h
@@ -33,6 +33,17 @@ template <typename T>
 class EventLoop {
  public:
   EventLoop() = default;
+  ~EventLoop() {
+    std::unique_lock<std::mutex> lock(mtx_);
+    std::packaged_task<T()> fn;
+    while (!tasks_.empty()){
+      fn = std::move(tasks_.front());
+      tasks_.pop_front();
+      if (fn.valid()) {
+        fn();  
+      }
+    }
+  }
   void run() {
     while (true) {
       std::packaged_task<T()> fn;


### PR DESCRIPTION
Fixes intermittent crash when quitting the R session causing by scheduling desynchronization.
Depending on the order this would be called:

https://github.com/mlverse/torch/blob/720a546f71e7a4d2765c550d6e5fd67b874f5d39/src/autograd.cpp#L69-L73

and the event loop stops. The thread would never be joined. This would cause a crash when exiting the R session because unjoined/undetached threads can cause problems.

We solved by having a special finalization tasks, that are called right before exiting the event loop.


