### PR TITLE
Modify utils-data-collate to handle logical vectors

### DIFF
--- a/R/utils-data-collate.R
+++ b/R/utils-data-collate.R
@@ -20,7 +20,7 @@ utils_data_default_collate <- function(batch) {
   } else if (is.numeric(elem) && length(elem) == 1) {
     k <- unlist(batch)
     return(torch_tensor(k, dtype = torch_float()))
-  }else if (is.logical(elem) && length(elem) == 1){
+  } else if (is.logical(elem) && length(elem) == 1){
     k <- unlist(batch)
     return(torch_tensor(k, dtype = torch_bool()))
   } else if (is.character(elem) && length(elem) == 1) {

--- a/R/utils-data-collate.R
+++ b/R/utils-data-collate.R
@@ -20,6 +20,9 @@ utils_data_default_collate <- function(batch) {
   } else if (is.numeric(elem) && length(elem) == 1) {
     k <- unlist(batch)
     return(torch_tensor(k, dtype = torch_float()))
+  }else if (is.logical(elem) && length(elem) == 1){
+    k <- unlist(batch)
+    return(torch_tensor(k, dtype = torch_bool()))
   } else if (is.character(elem) && length(elem) == 1) {
     return(unlist(batch))
   } else if (is.list(elem)) {


### PR DESCRIPTION
# Collating Logical Vectors

At present, `utils_data_default_collate`, the
default data collation function for `dataloader` instances, throws an error if
a batch of elements contains a logical vector. With slight modification, the function can
be revised to treat them the same way it does double and integer vectors. 

Here is a quick example. The example subclass
of `dataset` stores a list of tensors (in this case, containing random draws from the standard normal distribution). Indexing returns a list with the element at that index and a logical vector indicating whether the mean of the element is greater than 0 stores a list of tensors (in this case, containing random draws from the standard normal distribution). Indexing returns a list with the element at that index and a logical vector indicating whether the mean of the element is greater than 0.
```{r}
library(torch)
torch_manual_seed(1)
data <- replicate(10, torch_randn(5))

show_batches <- function(dl) {
  coro::loop(for (batch in dl) {
    print(batch)
  })
}

example_ds <- dataset("example_dataset",
  initialize = function(numbers) {
    self$numbers <- numbers
  },
  .getitem = function(i) {
    x <- self$numbers[[i]]
    list(x = x, n = as.array(torch_mean(x) > 0))
  },
  .length = function() length(self$numbers)
)

example_ds_inst <- example_ds(numbers = data)
```

Trying to iterate over batches with the default collation function fails because it has no case to handle logical vectors.

```
# Error: "Can't collate data of class list"
example_dl <- dataloader(example_ds_inst,
  batch_size = 2
)

show_batches(example_dl)
```

We can fix this by adding that case to the function. I decided to treat logicals the
same as doubles and integers: flatten and transform to a tensor of the type corresponding to the R type, in this case `torch_bool`. The function below contains the alterations I made to `utils_data_default_collate`.
```{r}
utils_data_default_collate2 <- function(batch) {
  elem <- batch[[1]]
  if (torch:::is_torch_tensor(elem)) {
    return(torch_stack(batch, dim = 1))
  } else if (torch:::is_tensor_like(elem)) {
    # here we rely on tensor like atomic vectors to be cast to torch tensors
    # before stacking.
    return(torch_stack(batch, dim = 1))
  } else if (is.integer(elem) && length(elem) == 1) {
    k <- unlist(batch)
    return(torch_tensor(k, dtype = torch_long()))
  } else if (is.numeric(elem) && length(elem) == 1) {
    k <- unlist(batch)
    return(torch_tensor(k, dtype = torch_float()))
  } else if (is.logical(elem) && length(elem) == 1) {
    k <- unlist(batch)
    return(torch_tensor(k, dtype = torch_bool()))
  } else if (is.character(elem) && length(elem) == 1) {
    return(unlist(batch))
  } else if (is.list(elem)) {
    lapply(torch:::transpose2(batch), utils_data_default_collate2)
  } else {
    torch:::value_error("Can't collate data of class: '{class(data)}'")
  }
}
```

This behavior might be desirable in cases where a dataset returns Boolean metadata about the index being sampled. I discovered the behavior this pull request tries to amend when working with a `dataset` instance that returned a list with a file path to an image and a logical indicating whether it was created by data augmentation.
```{r}
example_dl <- dataloader(example_ds_inst,
  batch_size = 2, collate_fn = utils_data_default_collate2
)

show_batches(example_dl)
```

The same capability could be extended to complex vectors as well, though I don't know if those are commonly enough used to be worth handling. It might also be possible to rewrite the multiple `else`
clauses in `utils_data_default_collate` into a nested pair of `if` clauses that check if `elem` is length 1 and then determine its type.
