### PR TITLE
Autoinstall

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ License: MIT + file LICENSE
 URL: https://torch.mlverse.org/docs, https://github.com/mlverse/torch
 BugReports: https://github.com/mlverse/torch/issues
 Encoding: UTF-8
-SystemRequirements: C++11, LibTorch (https://pytorch.org/)
+SystemRequirements: C++11, LibTorch (https://pytorch.org/); Only x86_64 platforms
+  are currently supported.
 LinkingTo:
     Rcpp
 Imports:

--- a/R/package.R
+++ b/R/package.R
@@ -30,12 +30,14 @@ globalVariables(c("..", "self", "private", "N"))
   autoinstall <- autoinstall && (!install_exists())
   
   if (autoinstall) {
-    
     install_success <- tryCatch(
       {
         cli::cli_alert_info("Additional software needs to be {.strong downloaded} and {.strong installed} for torch to work correctly.")
         check_can_autoinstall() # this errors if it's not possible to autoinstall for that system
-        if (is_interactive) {
+        # in interactive environments we want to ask the user for permission to
+        # download and install stuff. That's not necessary otherwise because the
+        # user has explicitly asked for installation with `TORCH_INSTALL=1`.
+        if (is_interactive) { 
           get_confirmation() # this will error of response is not true.  
         }
         install_torch()
@@ -44,7 +46,7 @@ globalVariables(c("..", "self", "private", "N"))
       error = function(e) {
         cli::cli_warn(c(
           i = "Failed to install torch, manually run install_torch()",
-          x = e$msg
+          x = e$message
         ))
         FALSE
       }
@@ -66,7 +68,10 @@ globalVariables(c("..", "self", "private", "N"))
         .compilation_unit <<- cpp_jit_compilation_unit()
       },
       error = function(e) {
-        warning("Torch failed to start, restart your R session to try again. ", e$message, call. = FALSE)
+        cli::cli_warn(c(
+          "torch failed to start, restart your R session to try again. ",
+          e$message
+        ))
         FALSE
       }
     )

--- a/R/package.R
+++ b/R/package.R
@@ -99,7 +99,7 @@ get_confirmation <-  function() {
 }
 
 check_can_autoinstall <- function() {
-  if (Sys.info()[["machine"]] != "x86_64") {
+  if (grepl("x86_64", Sys.info()[["machine"]])) {
     cli::cli_abort(c(
       "Currently only {.code x86_64} systems are supported for autoinstallation. ",
       i = "You can manually compile LibTorch for you architecture following instructions in {.url https://github.com/pytorch/pytorch#from-source}",

--- a/R/package.R
+++ b/R/package.R
@@ -14,19 +14,33 @@ globalVariables(c("..", "self", "private", "N"))
   cpp_torch_namespace__store_main_thread_id()
 
   install_success <- TRUE
+  
   autoinstall <- interactive() ||
     "JPY_PARENT_PID" %in% names(Sys.getenv()) ||
     identical(getOption("jupyter.in_kernel"), TRUE)
-
-  if (!install_exists() && Sys.getenv("TORCH_INSTALL", unset = 2) != 0 &&
-    (autoinstall || Sys.getenv("TORCH_INSTALL", unset = 2) == "1")) {
+  
+  # we only autoinstall if it has not explicitly disabled by setting 
+  # TORCH_INSTALL = 0
+  autoinstall <- autoinstall && (Sys.getenv("TORCH_INSTALL", unset = 2) != 0)
+  
+  # We can also auto install if TORCH_INSTALL is requested with TORCH_INSTALL=1
+  autoinstall <- autoinstall || (Sys.getenv("TORCH_INSTALL", unset = 2) == "1")
+  
+  # we only autoinstall if installation doesn't yet exist.
+  autoinstall <- autoinstall && (!install_exists())
+  
+  if (autoinstall) {
+    
     install_success <- tryCatch(
       {
-        install_torch()
+        cli::cli_alert_info("Additional software needs to be {.strong downloaded} and {.strong installed} for torch to work correctly.")
+        check_can_autoinstall() # this errors if it's not possible to autoinstall for that system
+        response <- get_confirmation() # this will error of response is not true.
+        if (response) install_torch()
         TRUE
       },
       error = function(e) {
-        warning("Failed to install Torch, manually run install_torch().\n ", e$message, call. = FALSE)
+        warning("Failed to install torch, manually run install_torch().\n ", e$message, call. = FALSE)
         FALSE
       }
     )
@@ -63,4 +77,23 @@ release_bullets <- function() {
     "Create the cran/ branch and update the branch variable",
     "Uncomment the indicated line in the .RBuildignore file"
   )
+}
+
+get_confirmation <-  function() {
+  response <- utils::askYesNo(msg = "Do you want to continue?")
+  if (is.na(response) || (!response)) {
+    stop("Aborted.", call. = FALSE)
+  }
+  TRUE
+}
+
+check_can_autoinstall <- function() {
+  if (Sys.info()[["machine"]] != "x86_64") {
+    cli::cli_abort(c(
+      "Currently only {.code x86_64} systems are supported for autoinstallation. ",
+      i = "You can manually compile LibTorch for you architecture following instructions in {.url https://github.com/pytorch/pytorch#from-source}",
+      i = "You can then use {.fn install_torch_from_file} to install manually."
+    ))
+  }
+  TRUE
 }

--- a/R/package.R
+++ b/R/package.R
@@ -15,13 +15,13 @@ globalVariables(c("..", "self", "private", "N"))
 
   install_success <- TRUE
   
-  autoinstall <- interactive() ||
+  is_interactive <- interactive() ||
     "JPY_PARENT_PID" %in% names(Sys.getenv()) ||
     identical(getOption("jupyter.in_kernel"), TRUE)
   
   # we only autoinstall if it has not explicitly disabled by setting 
   # TORCH_INSTALL = 0
-  autoinstall <- autoinstall && (Sys.getenv("TORCH_INSTALL", unset = 2) != 0)
+  autoinstall <- is_interactive && (Sys.getenv("TORCH_INSTALL", unset = 2) != 0)
   
   # We can also auto install if TORCH_INSTALL is requested with TORCH_INSTALL=1
   autoinstall <- autoinstall || (Sys.getenv("TORCH_INSTALL", unset = 2) == "1")
@@ -35,12 +35,17 @@ globalVariables(c("..", "self", "private", "N"))
       {
         cli::cli_alert_info("Additional software needs to be {.strong downloaded} and {.strong installed} for torch to work correctly.")
         check_can_autoinstall() # this errors if it's not possible to autoinstall for that system
-        response <- get_confirmation() # this will error of response is not true.
-        if (response) install_torch()
+        if (is_interactive) {
+          get_confirmation() # this will error of response is not true.  
+        }
+        install_torch()
         TRUE
       },
       error = function(e) {
-        warning("Failed to install torch, manually run install_torch().\n ", e$message, call. = FALSE)
+        cli::cli_warn(c(
+          i = "Failed to install torch, manually run install_torch()",
+          x = e$msg
+        ))
         FALSE
       }
     )

--- a/R/package.R
+++ b/R/package.R
@@ -69,8 +69,9 @@ globalVariables(c("..", "self", "private", "N"))
       },
       error = function(e) {
         cli::cli_warn(c(
-          "torch failed to start, restart your R session to try again. ",
-          e$message
+          i = "torch failed to start, restart your R session to try again.",
+          i = "You might need to reinstall torch using {.fn install_torch}",
+          x = e$message
         ))
         FALSE
       }

--- a/R/package.R
+++ b/R/package.R
@@ -99,7 +99,7 @@ get_confirmation <-  function() {
 }
 
 check_can_autoinstall <- function() {
-  if (grepl("x86_64", Sys.info()[["machine"]])) {
+  if (!grepl("x86_64", R.version$arch)) {
     cli::cli_abort(c(
       "Currently only {.code x86_64} systems are supported for autoinstallation. ",
       i = "You can manually compile LibTorch for you architecture following instructions in {.url https://github.com/pytorch/pytorch#from-source}",

--- a/R/utils-data-dataloader.R
+++ b/R/utils-data-dataloader.R
@@ -465,7 +465,15 @@ MultiProcessingDataLoaderIter <- R6::R6Class(
         
         # Raise error that might have hapened in the subprocess.
         if (!is.null(result$error)) {
-          runtime_error(result$error$message)
+          if (packageVersion("callr") >= "3.7.1") {
+            rlang::abort(
+              "Error when getting dataset item.", 
+              parent = result$error, 
+              class = "runtime_error"
+            )
+          } else {
+            runtime_error(result$error$message)  
+          }
         }
         
         data <- result$result


### PR DESCRIPTION
- We now don't automatically install torch. Instead, when loading torch we ask the user if additional dependecies can be installed.
- Improved error messages when an error happens during installation or if torch is just not installed.
- Added a note on the DESCRIPTION file stating that currently only x86_64 platforms are supported.
