### PR TITLE
Build binaries in old containers.

### DIFF
--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -7,7 +7,7 @@ on:
       - main
       - "cran/**"
       - "libtorch-v1.11.0"
-      - "speed-up-2"
+      - "build2"
 
 jobs:
   build:
@@ -33,6 +33,7 @@ jobs:
               artifact: "build/liblantern.so",
               upload: "Linux",
               fixlib: "chrpath -r '$ORIGIN/.' liblantern.so",
+              container: "ubuntu:18.04",
             }
           - {
               os: ubuntu-20.04,
@@ -50,6 +51,7 @@ jobs:
               cuda_patch: "1",
               cudnn: "https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-11.3-linux-x64-v8.2.1.32.tgz",
               fixlib: "chrpath -r '$ORIGIN/.' liblantern.so",
+              container: "ubuntu:18.04",
             }
           - {
               os: ubuntu-20.04,
@@ -60,6 +62,7 @@ jobs:
               cudnn: "https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-11.3-linux-x64-v8.2.1.32.tgz",
               fixlib: "chrpath -r '$ORIGIN/.' liblantern.so",
               pre_cxx11_abi: 1,
+              container: "ubuntu:18.04",
             }
           - {
               os: ubuntu-20.04,


### PR DESCRIPTION
Build Lantern binaries with older GCC version for maximum compatibility with older systems.