### PR TITLE
MPS allocator

### DIFF
--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -6,9 +6,6 @@ on:
       - master
       - main
       - "cran/**"
-      - "libtorch-1.12.1"
-      - "build2"
-      - "mps-allocator"
 
 jobs:
   build:

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -8,7 +8,7 @@ on:
       - "cran/**"
       - "libtorch-1.12.1"
       - "build2"
-      - "m1-mac"
+      - "mps-allocator"
 
 jobs:
   build:

--- a/R/install.R
+++ b/R/install.R
@@ -15,10 +15,10 @@ install_config <- list(
         ),
         aarch64 = list(
           libtorch = list(
-            url = "https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorch/libtorch-v1.12.1.zip",
+            url = "https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorch-for-R/libtorch-v1.12.1.zip",
             path = "libtorch/",
             filter = ".dylib",
-            md5hash = "d73b3d80dff28ab0fa647ca488cc3c2e"
+            md5hash = "90be2e718f10bf72280d595cbf5f70ef"
           ),
           "liblantern" = sprintf("https://storage.googleapis.com/torch-lantern-builds/refs/heads/%s/latest/macOSArm64-cpu.zip", branch)  
         )

--- a/R/install.R
+++ b/R/install.R
@@ -1,4 +1,4 @@
-branch <- "libtorch-1.12.1"
+branch <- "mps-allocator"
 
 install_config <- list(
   "1.12.1" = list(

--- a/R/lantern_sync.R
+++ b/R/lantern_sync.R
@@ -14,6 +14,7 @@ lantern_sync <- function(sync_lib = FALSE) {
   }
 
   if (sync_lib) {
+    lib_dest <- install_path()
     lib_src <- "lantern/build/liblantern"
 
     if (file.exists(paste0(lib_src, ".dylib"))) {
@@ -24,7 +25,7 @@ lantern_sync <- function(sync_lib = FALSE) {
       path <- list.files("lantern/build/Release/", full.names = TRUE)
     }
 
-    dir.create("inst/lib", showWarnings = FALSE, recursive = TRUE)
+    dir.create(file.path(lib_dest, "lib"), showWarnings = FALSE, recursive = TRUE)
 
     file.copy(
       path,

--- a/lantern/CMakeLists.txt
+++ b/lantern/CMakeLists.txt
@@ -45,7 +45,7 @@ if(APPLE)
       if ('${CMAKE_HOST_SYSTEM_PROCESSOR}' STREQUAL 'x86_64')
         retrieve_lib("https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.12.1.zip" "libtorch")
       elseif ('${CMAKE_HOST_SYSTEM_PROCESSOR}' STREQUAL 'arm64')
-        retrieve_lib("https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorch/libtorch-v1.12.1.zip" "libtorch")
+        retrieve_lib("https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorch-for-R/libtorch-v1.12.1.zip" "libtorch")
       else()
         message(FATAL_ERROR, "Arch not supported")
       endif()
@@ -163,6 +163,11 @@ set(LANTERN_SRC
     src/Compile.cpp
 )
 
+if(APPLE)
+  if('${CMAKE_HOST_SYSTEM_PROCESSOR}' STREQUAL 'arm64')
+    set(LANTERN_SRC ${LANTERN_SRC} src/AllocatorMPS.cpp)
+  endif()
+endif()
 
 if(DEFINED ENV{CUDA} AND NOT '$ENV{CUDA}' STREQUAL '')
  

--- a/lantern/src/AllocatorMPS.cpp
+++ b/lantern/src/AllocatorMPS.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#define LANTERN_BUILD
+#include <torch/torch.h>
+#include "AllocatorUtils.h"
+
+// this implementation is based on CUDACachingAllocator.
+// It utilizes Metal Heaps to improve the performance with buffer allocation.
+// TODO: Unify the logic with CUDACachingAllocator and remove redundant code.
+namespace at {
+namespace mps {
+
+
+class IMpsAllocatorCallback {
+ public:
+  enum class EventType {
+    ALLOCATED, // buffer got allocated to be used immediately
+    RECYCLED,  // buffer pulled from free list to be reused
+    FREED,     // buffer put to free list for future recycling
+    RELEASED,  // buffer memory released
+  };
+  virtual ~IMpsAllocatorCallback() = default;
+  virtual void executeMPSAllocatorCallback(void* ptr, EventType event) = 0;
+};
+
+// MPS allocator will execute every registered callback when a block of memory is freed.
+C10_DECLARE_REGISTRY(MPSAllocatorCallbacksRegistry, IMpsAllocatorCallback);
+#define REGISTER_MPS_ALLOCATOR_CALLBACK(name, ...) \
+  C10_REGISTER_CLASS(MPSAllocatorCallbacksRegistry, name, __VA_ARGS__);
+
+at::Allocator* getMPSStaticAllocator();
+
+int free_calls = 0;
+
+class MPSGarbageCollectorCallback : virtual public at::mps::IMpsAllocatorCallback {
+    public:
+    MPSGarbageCollectorCallback() = default;
+    ~MPSGarbageCollectorCallback() = default;
+    void executeMPSAllocatorCallback(void* ptr, EventType event) {
+     switch (event)
+     {
+        case EventType::ALLOCATED:
+        // seems to be currently unreachable
+            break;
+        case EventType::RECYCLED:
+        // seems to be currently unreachable
+            break;
+        case EventType::FREED:
+        // caling gc here will deadlock.
+            break;
+        case EventType::RELEASED:
+        // we want to call the gc in this situation:
+        // https://github.com/pytorch/pytorch/blob/664058fa83f1d8eede5d66418abff6e20bd76ca8/aten/src/ATen/mps/MPSAllocator.mm#L215
+            (*call_r_gc)(true);
+            wait_for_gc();
+            break;
+        default:
+            break;
+     }
+    }
+};
+
+REGISTER_MPS_ALLOCATOR_CALLBACK("gc", MPSGarbageCollectorCallback);
+
+}
+}
+

--- a/tests/testthat/test-mps.R
+++ b/tests/testthat/test-mps.R
@@ -8,3 +8,9 @@ test_that("can create tensors on the MPS device", {
   y <- torch_mm(x, x)
   expect_true(y$device == torch_device("mps", 0))
 })
+
+test_that("can allocate a bunch of tensors without OOM", {
+  expect_no_error({
+    for(i in 1:25) x <- torch_randn(10000, 10000, device="mps")  
+  })
+})

--- a/tools/buildlantern.R
+++ b/tools/buildlantern.R
@@ -9,6 +9,7 @@ if (dir.exists("lantern")) {
   })
 
   # copy lantern
+  source("R/install.R")
   source("R/lantern_sync.R")
   lantern_sync(TRUE)
 

--- a/vignettes/articles/memory-management.Rmd
+++ b/vignettes/articles/memory-management.Rmd
@@ -22,10 +22,10 @@ memory) because they still din't get garbage collected.
 
 To solve this problem, the torch package has implemented strategies to automatically
 call the R garbage collector when LibTorch is allocating more memory. The strategies
-are different depending on where the memory is being allocated: on the CPU or the
-GPU (CUDA devices).
+are different depending on where the memory is being allocated: on the CPU,
+GPU (CUDA devices) or [MPS](https://developer.apple.com/documentation/metalperformanceshaders) (on Apple Silicon machines/ or equipped with AMD GPU's).
 
-## CPU memory management
+## CPU
 
 On the CPU, torch will possibly call the R garbage collector in two moments:
 
@@ -53,7 +53,7 @@ On the CPU, torch will possibly call the R garbage collector in two moments:
    a lot of overhead, so this will probably slow down the program execution.
 
 
-## CUDA memory management
+## CUDA
 
 CUDA memory tends to be scarcer than CPU memory, also, allocation must be faster
 otherwise allocation overhead can counterbalance the speed up of GPU. To make
@@ -97,3 +97,11 @@ as described below. The behavior of caching allocator can be controlled via envi
 - `garbage_collection_threshold` helps actively reclaiming unused GPU memory to avoid triggering expensive sync-and-reclaim-all operation (release_cached_blocks), which can be unfavorable to latency-critical GPU applications (e.g., servers). Upon setting this threshold (e.g., 0.8), the allocator will start reclaiming GPU memory blocks if the GPU memory capacity usage exceeds the threshold (i.e., 80% of the total memory allocated to the GPU application). The algorithm prefers to free old & unused blocks first to avoid freeing blocks that are actively being reused. The threshold value should be between greater than 0.0 and less than 1.0.
 
 Notice that the garbage collector refered below is not the R garbage collector but LibTorch's collector, that releases memory from the cache to the OS.
+
+## MPS
+
+Memory management in MPS devices is very similar to the strategy used in CUDA devices,
+except that here there's currently no configuration or tuning possible. The R garbage
+collector will be called whenever there's no more available memory for the GPU and thus,
+possibly deleting some Tensors. Allocation is then retried and if it fails, a OOM
+error is raised.


### PR DESCRIPTION
- Fix #891 Uses a custom pre-built binary of LibTorch when on M1 macs. The binary patches libtorch with modifications from [this file](https://github.com/mlverse/libtorch-mac-m1/blob/2343ddd4dce743d5bf65f513fe07d0021e59383e/patch/MPSAllocator-v1.12.1.patch
). This allows better memory management as we don't keep allocating memory indefinitely. The dev version of pytorch already implements better memory management, but the ability to use callbacks has been removed in https://github.com/pytorch/pytorch/pull/86119 thus we will probably need to patch differently when updating to LibTorch v1.13.

- Should also fix #894 , as the pre-built binaries no longer link to openMP.