### PR TITLE
Subset classes

### DIFF
--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -148,6 +148,9 @@ dataset_subset <- dataset(
     if (!is.null(dataset$.getbatch)) {
       self$.getbatch <- self$.getitem
     }
+    classes <- class(dataset)
+    classes_to_append <- classes[classes != "R6"]
+    class(self) <- c(paste0(classes_to_append, "_subset"), classes)
   },
   .getitem = function(idx) {
     return(self$dataset[self$indices[idx]])

--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -150,7 +150,7 @@ dataset_subset <- dataset(
     }
     classes <- class(dataset)
     classes_to_append <- classes[classes != "R6"]
-    class(self) <- c(paste0(classes_to_append, "_subset"), classes)
+    class(self) <- c(paste0(classes_to_append, "_subset"), class(self))
   },
   .getitem = function(idx) {
     return(self$dataset[self$indices[idx]])

--- a/tests/testthat/test-utils-data.R
+++ b/tests/testthat/test-utils-data.R
@@ -149,6 +149,6 @@ test_that("dataset subset adds more classes", {
   testing_sub <- dataset_subset(testing, 1:2)
   expect_equal(
     class(testing_sub), 
-    c("minimal_subset", "dataset_subset", "minimal", "dataset", "R6")
+    c("minimal_subset", "dataset_subset", "dataset", "R6")
   )
 })

--- a/tests/testthat/test-utils-data.R
+++ b/tests/testthat/test-utils-data.R
@@ -133,3 +133,22 @@ test_that("datasets have a custom print method", {
 
   expect_output(print(data), regex = "dataset_generator")
 })
+
+test_that("dataset subset adds more classes", {
+  minimal_dataset <- dataset(
+    "minimal",
+    initialize = function() {
+      self$data <- torch_tensor(1:5)
+    },
+    .length = function() {
+      self$data$size()[[1]]
+    }
+  )
+  testing <- minimal_dataset()
+  expect_equal(class(testing), c("minimal", "dataset", "R6"))
+  testing_sub <- dataset_subset(testing, 1:2)
+  expect_equal(
+    class(testing_sub), 
+    c("minimal_subset", "dataset_subset", "minimal", "dataset", "R6")
+  )
+})


### PR DESCRIPTION
Fix #881 

@jonthegeek We now append `_subset` to the base dataset class, so you can easily write S3 methods for it if necessary.
I don't think there's a safe way to forward the base object methods to the subset as those methods won't know about the selected index and etc. But at least you can now write a custom `$` method for your dataset.