### PR TITLE
Default generator

### DIFF
--- a/src/torch_api.cpp
+++ b/src/torch_api.cpp
@@ -648,15 +648,12 @@ SEXP operator_sexp_optional_generator(const XPtrTorchOptionalGenerator* self) {
 }
 
 XPtrTorchOptionalGenerator from_sexp_optional_generator(SEXP x) {
-  // We actualy do the same as we do with non-optional Generator's which is
-  // getting the default LibTorch Generator and pass that.
-  // This is because we want to have full control over the default Generator
-  // to be able to make changes that don't break backward compatibility.
-
   Rcpp::Function torch_option =
         Rcpp::Environment::namespace_env("torch").find("torch_option");
 
   if (TYPEOF(x) == NILSXP && !Rcpp::as<bool>(torch_option("old_seed_behavior", false))) {
+    // When we are not using the old seed behavior, we can let LibTorch 
+    // grab the correct generator.
     return XPtrTorchOptionalGenerator(lantern_optional_generator(nullptr));
   } else {
     return XPtrTorchOptionalGenerator(

--- a/src/torch_api.cpp
+++ b/src/torch_api.cpp
@@ -652,8 +652,16 @@ XPtrTorchOptionalGenerator from_sexp_optional_generator(SEXP x) {
   // getting the default LibTorch Generator and pass that.
   // This is because we want to have full control over the default Generator
   // to be able to make changes that don't break backward compatibility.
-  return XPtrTorchOptionalGenerator(
-      lantern_optional_generator(Rcpp::as<XPtrTorchGenerator>(x).get()));
+
+  Rcpp::Function torch_option =
+        Rcpp::Environment::namespace_env("torch").find("torch_option");
+
+  if (TYPEOF(x) == NILSXP && !Rcpp::as<bool>(torch_option("old_seed_behavior", false))) {
+    return XPtrTorchOptionalGenerator(lantern_optional_generator(nullptr));
+  } else {
+    return XPtrTorchOptionalGenerator(
+        lantern_optional_generator(Rcpp::as<XPtrTorchGenerator>(x).get()));
+  }
 }
 
 void delete_optional_generator(void* x) {

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -35,3 +35,20 @@ test_that("current behavior is identical to pytorch", {
     expect_equal_to_r(torch_randn(1), -0.364226043224335)
   })
 })
+
+test_that("can use torch bernoulli on cuda.", {
+  # see https://github.com/mlverse/torch/issues/480
+  expect_error({
+    x <- torch_bernoulli(torch_ones(3,3, device="cpu") * 0.5)
+  }, regexp = NA)
+  expect_tensor_shape(x, c(3,3))
+  
+  skip_if_cuda_not_available()
+  
+  expect_error({
+    x <- torch_bernoulli(torch_ones(3,3, device="cuda") * 0.5)
+  }, regexp = NA)
+  expect_tensor_shape(x, c(3,3))
+  
+}) 
+  


### PR DESCRIPTION
Fix #480 

We now let LibTorch grab the default generator when it's not explicitly passed.