### PR TITLE
Register functions from the torch api

### DIFF
--- a/inst/include/torch_imports.h
+++ b/inst/include/torch_imports.h
@@ -130,6 +130,8 @@ IMPORT_FROM_SEXP(from_sexp_vector_string, XPtrTorchvector_string)
 IMPORT_FROM_SEXP(from_sexp_variable_list, XPtrTorchvariable_list)
 IMPORT_FROM_SEXP(from_sexp_string_view, XPtrTorchstring_view)
 IMPORT_FROM_SEXP(from_sexp_optional_string_view, XPtrTorchoptional_string_view)
+IMPORT_FROM_SEXP(from_sexp_sym_int_array_ref, XPtrTorchSymIntArrayRef)
+IMPORT_FROM_SEXP(from_sexp_sym_int, XPtrTorchSymInt)
 
 #define IMPORT_DELETER(name)                                \
   void name(void* x) {                                      \

--- a/src/torch_exports.cpp
+++ b/src/torch_exports.cpp
@@ -101,6 +101,8 @@ void register_callables(DllInfo *dll) {
   REGISTER_C_CALLABLE(from_sexp_variable_list)
   REGISTER_C_CALLABLE(from_sexp_string_view)
   REGISTER_C_CALLABLE(from_sexp_optional_string_view)
+  REGISTER_C_CALLABLE(from_sexp_sym_int_array_ref)
+  REGISTER_C_CALLABLE(from_sexp_sym_int)
 
   REGISTER_C_CALLABLE(delete_tensor)
   REGISTER_C_CALLABLE(delete_script_module)


### PR DESCRIPTION
To allow C++ extensions to compile correctly.

Fix #910 