### PR TITLE
Unwind protect

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS = -I../inst/include/
+PKG_CPPFLAGS = -I../inst/include/ -DRCPP_NO_UNWIND_PROTECT
 
 .PHONY: rename_init
 all: $(SHLIB) rename


### PR DESCRIPTION
Rcpp v1.0.10 made unwind protect the default and this breaks our logic to catch error messages that happened within R callbacks - thus we disable that feature by default. In the future we should look into other ways to handle this.
