### PR TITLE
Packaging

### DIFF
--- a/.github/actions/install-cudnn/action.yml
+++ b/.github/actions/install-cudnn/action.yml
@@ -18,6 +18,7 @@ runs:
     - name: Install cuDNN (Linux)
       if: ${{ runner.os == 'Linux' }}
       run: |
+        apt-get install -y wget
         find $CUDA_PATH -maxdepth 2 -type d -ls
         wget --quiet ${{ steps.cudnn_url.outputs.cudnn_url }} -O cudnn.tgz
         tar -xzvf cudnn.tgz

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1
         with:
-          cmake-version: "latest"
+          cmake-version: "3.25.1"
 
       - name: Install CUDA
         if: ${{matrix.cuda != ''}}

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -78,6 +78,7 @@ jobs:
           dir.create(dest_path, recursive = TRUE)
           binary_path <- pkgbuild::build(binary = TRUE, dest_path=dest_path)
           tools::write_PACKAGES(dest_path, type = "${{ matrix.type }}")
+          cat("pkg_version=", desc::desc_get("Version"), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep="")
         shell: Rscript {0}
         
       - id: 'auth'
@@ -89,7 +90,6 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: "../binaries"
-          destination: 'torch-lantern-builds/packages/${{ matrix.version }}/'
+          destination: 'torch-lantern-builds/packages/${{ matrix.version }}/${{ steps.build.outputs.pkg_version }}/'
           parent: false
       
-          

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -15,14 +15,20 @@ jobs:
       matrix:
         
         config: 
-          - {os: windows, version: cu11.3, runner: windows-2019}
-          - {os: ubuntu, version: cu11.3, runner: [self-hosted, gce, disk]}
-        
+          - {os: macOS, version: cpu-intel, runner: macOS-latest}
+          - {os: macOS, version: cpu-m1, runner: [self-hosted, m1]}
+          
+          - {os: ubuntu, version: cpu, runner: ubuntu-latest}
+          - {os: ubuntu, version: cu113, runner: [self-hosted, gce, disk]}
+          
+          - {os: windows, version: cpu, runner: windows-2019}
+          - {os: windows, version: cu113, runner: windows-2019}
+          
         r_version: [release]
           
         include:
           
-          - config: {version: cu11.3}
+          - config: {version: cu113}
             cuda: 11.3
             cuda_patch: 1
             
@@ -32,6 +38,9 @@ jobs:
             
           - config: {os: windows}
             type: 'win.binary'
+            
+          - config: {os: macOS}
+            type: 'mac.binary'
             
     env:
       CUDA: ${{ matrix.cuda }}

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -16,7 +16,7 @@ jobs:
         
         config: 
           - {os: windows, version: cu11.3, runner: windows-2019}
-          - {os: ubuntu, version: cu11.3, runner: ubuntu-latest}
+          - {os: ubuntu, version: cu11.3, runner: [self-hosted, gce, disk]}
         
         r_version: [release]
           

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           binary_path <- pkgbuild::build(binary = TRUE)
           cat("binary_path=", path.expand(binary_path), "\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
-          cat("binary_platform=", paste(R.Version()$os,R.Version()$arch,R.Version()$major,R.Version()$minor,sep = "/"),"\n",sep="",file=Sys.getenv("GITHUB_OUTPUT"))
+          cat("binary_platform=", paste(R.Version()$os,R.Version()$arch,R.Version()$major,R.Version()$minor,sep = "/"),"\n",sep="",file=Sys.getenv("GITHUB_OUTPUT"),append=TRUE)
         shell: Rscript {0}
         
       - id: 'auth'

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -77,7 +77,7 @@ jobs:
           dest_path <- contrib.url("../binaries", type="binary")
           dir.create(dest_path, recursive = TRUE)
           binary_path <- pkgbuild::build(binary = TRUE, dest_path=dest_path)
-          tools::write_PACKAGES(dest_path, type = "${{ matrix.type }}")
+          tools::write_PACKAGES(dest_path, type = "${{ matrix.type }}", addFiles = TRUE)
           cat("pkg_version=", desc::desc_get("Version"), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep="")
         shell: Rscript {0}
         

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -1,0 +1,82 @@
+name: Packaging
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  build:
+   runs-on: ${{ matrix.config.runner }}
+   container: ${{ matrix.container }}
+   strategy:
+      fail-fast: false
+      matrix:
+        
+        config: 
+          - {os: windows, version: cu11.3, runner: windows-2019}
+          
+        r_version: [release]
+          
+        include:
+          
+          - config: {version: cu11.3}
+            cuda: 11.3
+            cuda_patch: 1
+            
+    env:
+      CUDA: ${{ matrix.cuda }}
+      PRECXX11ABI: ${{ matrix.precxx11abi }}
+      CMAKE_FLAGS: "-DBUNDLE_DEPENDENCIES=1"
+      BUILD_LANTERN: 1
+      
+    steps:
+            
+      - uses: actions/checkout@v3
+      
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: "latest"
+
+      - name: Install CUDA
+        if: ${{matrix.cuda != ''}}
+        uses: Jimver/cuda-toolkit@v0.2.8
+        id: cuda-toolkit
+        with:
+          cuda: "${{matrix.cuda}}.${{matrix.cuda_patch}}"
+          
+      - name: Install CuDNN
+        if: ${{ matrix.cuda != '' }}
+        uses: ./.github/actions/install-cudnn
+        with:
+          cuda_version: ${{ matrix.cuda }}
+          
+      - uses: ./.github/actions/setup-r
+        with:
+          r_version: ${{ matrix.r_version}}
+          
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache: false
+          extra-packages: any::rcmdcheck
+          needs: check
+          
+      - name: Build binary package
+        id: build
+        runs: |
+          binary_path <- pkgbuild::build(binary = TRUE)
+          cudnn_url=$(echo $CUDNN_URL)" >> $GITHUB_OUTPUT
+          cat("binary_path='", path.expand(binary_path), "'\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
+        shell: Rscript {0}
+        
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GCP_APPLICATION_CREDENTIALS }}
+
+      - id: 'upload-file'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: ${{ steps.build.outputs.binary_path }}
+          destination: 'torch-lantern-builds/packages/'
+      
+          

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
   
 jobs:
-  build:
-   runs-on: ${{ matrix.config.runner }}
-   container: ${{ matrix.container }}
-   strategy:
+  binaries:
+    runs-on: ${{ matrix.config.runner }}
+    container: ${{ matrix.container }}
+    strategy:
       fail-fast: false
       matrix:
         
         config: 
           - {os: windows, version: cu11.3, runner: windows-2019}
-          
+        
         r_version: [release]
           
         include:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -28,10 +28,14 @@ jobs:
             
           - config: {os: ubuntu}
             container: ubuntu:18.04
+            type: 'source'
+            
+          - config: {os: windows}
+            type: 'win.binary'
             
     env:
       CUDA: ${{ matrix.cuda }}
-      CMAKE_FLAGS: "-DBUNDLE_DEPENDENCIES=1"
+      CMAKE_FLAGS: "-DBUNDLE_DEPENDENCIES=ON"
       BUILD_LANTERN: 1
       DEBIAN_FRONTEND: noninteractive
       
@@ -70,9 +74,10 @@ jobs:
       - name: Build binary package
         id: build
         run: |
-          binary_path <- pkgbuild::build(binary = TRUE)
-          cat("binary_path=", path.expand(binary_path), "\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
-          cat("binary_platform=", paste(R.Version()$os,R.Version()$arch,R.Version()$major,R.Version()$minor,sep = "/"),"\n",sep="",file=Sys.getenv("GITHUB_OUTPUT"),append=TRUE)
+          dest_path <- contrib.url("../binaries", type="binary")
+          dir.create(dest_path, recursive = TRUE)
+          binary_path <- pkgbuild::build(binary = TRUE, dest_path)
+          tools::write_PACKAGES(dest_path, type = "${{ matrix.type }}")
         shell: Rscript {0}
         
       - id: 'auth'
@@ -83,7 +88,8 @@ jobs:
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: ${{ steps.build.outputs.binary_path }}
-          destination: 'torch-lantern-builds/packages/${{ steps.build.outputs.binary_platform }}/'
+          path: "../binaries"
+          destination: 'torch-lantern-builds/packages/${{ matrix.version }}/'
+          parent: false
       
           

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -33,6 +33,7 @@ jobs:
       CUDA: ${{ matrix.cuda }}
       CMAKE_FLAGS: "-DBUNDLE_DEPENDENCIES=1"
       BUILD_LANTERN: 1
+      DEBIAN_FRONTEND: noninteractive
       
     steps:
     

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - packaging
+      - main
+      - cran/*
+  schedule:
+    - cron: "0 2 * * *"
   
 jobs:
   binaries:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -90,6 +90,6 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: "../binaries"
-          destination: 'torch-lantern-builds/packages/${{ matrix.version }}/${{ steps.build.outputs.pkg_version }}/'
+          destination: 'torch-lantern-builds/packages/${{ matrix.config.version }}/${{ steps.build.outputs.pkg_version }}/'
           parent: false
       

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -37,15 +37,11 @@ jobs:
       
     steps:
     
-      - name: Install system dependencies
-        if: matrix.container != ''
-        run: |
-          apt update
-          apt install -y curl sudo libxml2-dev wget chrpath rsync git
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          DRY_RUN=1 sh ./get-docker.sh
-            
       - uses: actions/checkout@v3
+      
+      - uses: ./.github/actions/setup-r
+        with:
+          r_version: ${{ matrix.r_version}}
       
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1
@@ -64,10 +60,6 @@ jobs:
         uses: ./.github/actions/install-cudnn
         with:
           cuda_version: ${{ matrix.cuda }}
-          
-      - uses: ./.github/actions/setup-r
-        with:
-          r_version: ${{ matrix.r_version}}
           
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -16,6 +16,7 @@ jobs:
         
         config: 
           - {os: windows, version: cu11.3, runner: windows-2019}
+          - {os: ubuntu, version: cu11.3, runner: [self-hosted, gce, disk]}
         
         r_version: [release]
           
@@ -25,13 +26,23 @@ jobs:
             cuda: 11.3
             cuda_patch: 1
             
+          - config: {os: ubuntu}
+            container: ubuntu:18.04
+            
     env:
       CUDA: ${{ matrix.cuda }}
-      PRECXX11ABI: ${{ matrix.precxx11abi }}
       CMAKE_FLAGS: "-DBUNDLE_DEPENDENCIES=1"
       BUILD_LANTERN: 1
       
     steps:
+    
+      - name: Install system dependencies
+        if: matrix.container != ''
+        run: |
+          apt update
+          apt install -y curl sudo libxml2-dev wget chrpath rsync git
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          DRY_RUN=1 sh ./get-docker.sh
             
       - uses: actions/checkout@v3
       
@@ -68,6 +79,7 @@ jobs:
         run: |
           binary_path <- pkgbuild::build(binary = TRUE)
           cat("binary_path=", path.expand(binary_path), "\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
+          cat("binary_platform=", paste(R.Version()$os,R.Version()$arch,R.Version()$major,R.Version()$minor,sep = "/"),"\n",sep="",file=Sys.getenv("GITHUB_OUTPUT"))
         shell: Rscript {0}
         
       - id: 'auth'
@@ -79,6 +91,6 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: ${{ steps.build.outputs.binary_path }}
-          destination: 'torch-lantern-builds/packages/'
+          destination: 'torch-lantern-builds/packages/${{ steps.build.outputs.binary_platform }}/'
       
           

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           dest_path <- contrib.url("../binaries", type="binary")
           dir.create(dest_path, recursive = TRUE)
-          binary_path <- pkgbuild::build(binary = TRUE, dest_path)
+          binary_path <- pkgbuild::build(binary = TRUE, dest_path=dest_path)
           tools::write_PACKAGES(dest_path, type = "${{ matrix.type }}")
         shell: Rscript {0}
         

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -62,7 +62,7 @@ jobs:
           
       - name: Build binary package
         id: build
-        runs: |
+        run: |
           binary_path <- pkgbuild::build(binary = TRUE)
           cudnn_url=$(echo $CUDNN_URL)" >> $GITHUB_OUTPUT
           cat("binary_path='", path.expand(binary_path), "'\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -16,7 +16,7 @@ jobs:
         
         config: 
           - {os: windows, version: cu11.3, runner: windows-2019}
-          - {os: ubuntu, version: cu11.3, runner: [self-hosted, gce, disk]}
+          - {os: ubuntu, version: cu11.3, runner: ubuntu-latest}
         
         r_version: [release]
           

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -67,7 +67,6 @@ jobs:
         id: build
         run: |
           binary_path <- pkgbuild::build(binary = TRUE)
-          cudnn_url=$(echo $CUDNN_URL)" >> $GITHUB_OUTPUT
           cat("binary_path='", path.expand(binary_path), "'\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
         shell: Rscript {0}
         

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -2,6 +2,9 @@ name: Packaging
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - packaging
   
 jobs:
   binaries:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1
         with:
-          cmake-version: "latest"
+          cmake-version: "3.25.1"
 
       - name: Install CUDA
         if: ${{matrix.cuda != ''}}

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -67,7 +67,7 @@ jobs:
         id: build
         run: |
           binary_path <- pkgbuild::build(binary = TRUE)
-          cat("binary_path='", path.expand(binary_path), "'\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
+          cat("binary_path=", path.expand(binary_path), "\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"))
         shell: Rscript {0}
         
       - id: 'auth'

--- a/src/lantern/CMakeLists.txt
+++ b/src/lantern/CMakeLists.txt
@@ -222,7 +222,8 @@ install(
     PUBLIC_HEADER DESTINATION include/lantern
 )
 
-if (DEFINED BUNDLE_DEPENDENCIES)
+option(BUNDLE_DEPENDENCIES "On or off" OFF)
+if (BUNDLE_DEPENDENCIES)
     install(DIRECTORY ${TORCH_PATH} DESTINATION .)
     install(TARGETS lantern RUNTIME_DEPENDENCY_SET lantern_deps)
     install(RUNTIME_DEPENDENCY_SET lantern_deps 

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -107,12 +107,17 @@ Packages provided by the CRAN-like repository bundles all necessary for its exec
 including CUDA and CUDNN in the case of the GPU builds. This means that by installing it
 **you agree** with the included software licenses. See PyTorch's [LICENSE](https://github.com/pytorch/pytorch/blob/master/LICENSE) and [CUDA libraries EULA](http://docs.nvidia.com/cuda/eula/#redistribution-rights).
 
+When installing from the pre-built binaries, you **don't need** to manually install
+CUDA or cuDNN. If you have CUDA installed, it doesn't need to match the installation
+*'kind'* chosen below.
+
 To install from the pre-built binaries, you can use the following:
 
 ``` r
+options(timeout = 600) # increasing timeout is recommended since we will be downloading a 2GB file.
 kind <- "cu113" # "cpu", "cu113" are the only currently supported.
 version <- "0.9.1.9000"
-option(repos = c(
+options(repos = c(
   torch = sprintf("https://storage.googleapis.com/torch-lantern-builds/packages/%s/%s/", kind, version),
   CRAN = "https://cloud.r-project.org" # or any other from which you want to install the other R dependencies.
 ))

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -18,6 +18,11 @@ knitr::opts_chunk$set(
 
 After the usual R package installation, `torch` requires installing other 2 libraries: LibTorch and LibLantern. They are automatically installed by detecting information about you OS if you are using `torch` in interactive mode. If you are running `torch` in non-interactive environments you need to set the `TORCH_INSTALL` env var to 1, so it's automatically installed or manually call `torch::install_torch()`.
 
+Starting from torch v0.9.1.9000 it's possible to install torch from pre-built package binaries 
+available in a custom CRAN-like repository. This binaries include all shared objects necessary
+to run torch, thus it's not required to install any additional software. See the
+[*Install from pre-built binaries*](#pre-built) session for more information.
+
 We have provide pre-compiled binaries for all major platforms and you can find specific installation instructions below.
 
 ## Windows
@@ -92,6 +97,28 @@ install.packages("torch")
 
 If you have followed default installation locations we will detect that you have CUDA software installed and automatically download the GPU enabled Lantern binaries. You can also specify the `CUDA` env var with something like `Sys.setenv(CUDA="10.2")` if you want to force an specific version of the CUDA toolkit.
 
+## Installing from pre-built binaries
+
+As of torch v0.9.1.9000 it's now possible to install torch from pre-built package binaries
+from a CRAN like repository hosted on Google Cloud Storage. We currently provide pre-built
+binaries for CPU (for macOS, Linux and Windows) and GPU (Windows and Linux). 
+
+Packages provided by the CRAN-like repository bundles all necessary for its execution,
+including CUDA and CUDNN in the case of the GPU builds. This means that by installing it
+**you agree** with the included software licenses. See PyTorch's [LICENSE](https://github.com/pytorch/pytorch/blob/master/LICENSE) and [CUDA libraries EULA](http://docs.nvidia.com/cuda/eula/#redistribution-rights).
+
+To install from the pre-built binaries, you can use the following:
+
+``` r
+kind <- "cu113" # "cpu", "cu113" are the only currently supported.
+version <- "0.9.1.9000"
+option(repos = c(
+  torch = sprintf("https://storage.googleapis.com/torch-lantern-builds/packages/%s/%s/", kind, version),
+  CRAN = "https://cloud.r-project.org" # or any other from which you want to install the other R dependencies.
+))
+install.packages("torch")
+```
+
 ## Troubleshooting
 
 ### Large file download timeout
@@ -129,4 +156,3 @@ get_install_libs_url(type = "10.2")
 install_torch_from_file(libtorch = "file:///tmp/libtorch-cxx11-abi-shared-with-deps-1.7.1%2Bcu101.zip",
                         liblantern = "file:///tmp/Linux-gpu-101.zip")
 ```
-


### PR DESCRIPTION
Adds a GH Actions workflow that builds package binaries and uploads them to a CRAN like repository.
This makes installation easier and faster - specially when requesting the GPU versions.
