### PR TITLE
Returning tensors lists much faster.

### DIFF
--- a/src/torch_api.cpp
+++ b/src/torch_api.cpp
@@ -170,12 +170,12 @@ XPtrTorchIndexTensor from_sexp_index_tensor(SEXP x) {
 // tensor_list
 
 SEXP operator_sexp_tensor_list(const XPtrTorchTensorList* self) {
-  Rcpp::List out;
   int64_t sze = lantern_TensorList_size(self->get());
-
+  Rcpp::List out(sze);
+  
   for (int i = 0; i < sze; i++) {
     void* tmp = lantern_TensorList_at(self->get(), i);
-    out.push_back(XPtrTorchTensor(tmp));
+    out[i] = XPtrTorchTensor(tmp);
   }
 
   return out;


### PR DESCRIPTION
Fixes #992 

```
> bench::mark(a = {splitted <- torch::torch_split(sortedTensor[,2], counts)})
# A tibble: 1 × 13
  expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result          memory     time           gc      
  <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>          <list>     <list>         <list>  
1 a             177ms    177ms      5.58    1.15MB        0     3     0      538ms <list [74,999]> <Rprofmem> <bench_tm [3]> <tibble>
```

compared to 

```
# A tibble: 1 × 13
  expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result          memory     time           gc      
  <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>          <list>     <list>         <list>  
1 a             1.11m    1.11m    0.0150      21GB     4.12     1   275      1.11m <list [74,999]> <Rprofmem> <bench_tm [1]> <tibble>
```