### PR TITLE
Improve error message when installing from GitHub.

### DIFF
--- a/R/gen-namespace-docs.R
+++ b/R/gen-namespace-docs.R
@@ -5458,7 +5458,7 @@ NULL
 #' formed by [torch_geqrf()] that is represented by `(a, tau)` (given by (`input`, `input2`)).
 #' 
 #' This directly calls the underlying LAPACK function `?ormqr`.
-#' See [LAPACK documentation for ormqr](https://www.intel.com/content/www/us/en/develop/documentation/onemkl-developer-reference-c/top.html) for further details.
+#' See [LAPACK documentation for ormqr](https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2023-0/overview.html) for further details.
 #'
 #'
 #' @param self (Tensor) the `a` from [`torch_geqrf`].

--- a/man/install_torch.Rd
+++ b/man/install_torch.Rd
@@ -28,7 +28,8 @@ older versions of GLIBC like CentOS7 and older Debian/Ubuntu versions.
 \item \code{LANTERN_BASE_URL}: The base URL for lantern files. This allows passing a directory
 where lantern binaries are located. The filename is then constructed as usual.
 \item \code{TORCH_COMMIT_SHA}: torch repository commit sha to be used when querying lantern
-uploads.
+uploads. Set it to \code{'none'} to avoid looking for build for that commit and
+use the latest build for the branch.
 }
 
 The \code{TORCH_INSTALL} environment

--- a/man/torch_ormqr.Rd
+++ b/man/torch_ormqr.Rd
@@ -28,6 +28,6 @@ Multiplies \code{mat} (given by \code{input3}) by the orthogonal \code{Q} matrix
 formed by \code{\link[=torch_geqrf]{torch_geqrf()}} that is represented by \verb{(a, tau)} (given by (\code{input}, \code{input2})).
 
 This directly calls the underlying LAPACK function \code{?ormqr}.
-See \href{https://www.intel.com/content/www/us/en/develop/documentation/onemkl-developer-reference-c/top.html}{LAPACK documentation for ormqr} for further details.
+See \href{https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2023-0/overview.html}{LAPACK documentation for ormqr} for further details.
 }
 

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -105,7 +105,7 @@ binaries for CPU (for macOS, Linux and Windows) and GPU (Windows and Linux).
 
 Packages provided by the CRAN-like repository bundles all necessary for its execution,
 including CUDA and CUDNN in the case of the GPU builds. This means that by installing it
-**you agree** with the included software licenses. See PyTorch's [LICENSE](https://github.com/pytorch/pytorch/blob/master/LICENSE) and [CUDA libraries EULA](http://docs.nvidia.com/cuda/eula/#redistribution-rights).
+**you agree** with the included software licenses. See PyTorch's [LICENSE](https://github.com/pytorch/pytorch/blob/master/LICENSE) and [CUDA libraries EULA](https://docs.nvidia.com/cuda/eula/).
 
 When installing from the pre-built binaries, you **don't need** to manually install
 CUDA or cuDNN. If you have CUDA installed, it doesn't need to match the installation


### PR DESCRIPTION
This will help when installing from a commit that doesn't have a lantern build associated.