### PR TITLE
Build lantern on macOS 11

### DIFF
--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -15,7 +15,7 @@ jobs:
         config: 
           # when changing supported versions here, please modify supported versions
           # in install.R
-          - {os: macOS, version: cpu-intel, runner: macOS-latest}
+          - {os: macOS, version: cpu-intel, runner: macos-11}
           - {os: macOS, version: cpu-m1, runner: [self-hosted, m1]}
           
           - {os: ubuntu, version: cpu, runner: ubuntu-latest}


### PR DESCRIPTION
Build lantern on macOS11 for maximum compatibility.
relates to #1021 