### PR TITLE
Faster state dict loading

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -14461,8 +14461,8 @@ cpp_tensor_load <- function(input, device, base64) {
     .Call(`_torch_cpp_tensor_load`, input, device, base64)
 }
 
-cpp_load_state_dict <- function(path) {
-    .Call(`_torch_cpp_load_state_dict`, path)
+cpp_load_state_dict <- function(path, legacy_stream = FALSE) {
+    .Call(`_torch_cpp_load_state_dict`, path, legacy_stream)
 }
 
 cpp_torch_scalar <- function(x) {

--- a/R/save.R
+++ b/R/save.R
@@ -196,12 +196,15 @@ torch_load_list <- function(obj, device = NULL) {
 #' in pytorch's C++ api.
 #'
 #' @param path to the state dict file
+#' @param legacy_stream if `TRUE` then the state dict is loaded using a
+#'   a legacy way of handling streams.
+#' @param ... additional arguments that are currently not used.
 #'
 #' @return a named list of tensors.
 #'
 #' @export
 #' @concept serialization
-load_state_dict <- function(path) {
+load_state_dict <- function(path, ..., legacy_stream = FALSE) {
   path <- normalizePath(path)
   o <- cpp_load_state_dict(path)
 

--- a/inst/include/lantern/lantern.h
+++ b/inst/include/lantern/lantern.h
@@ -589,11 +589,11 @@ LANTERN_OPTIONAL_DECLS(string_view)
   LANTERN_API void*(LANTERN_PTR _lantern_jit_execute)(void* name, void* stack);
   HOST_API void* lantern_jit_execute(void* name, void* stack) {LANTERN_CHECK_LOADED void* ret = _lantern_jit_execute(name, stack); LANTERN_HOST_HANDLER return ret;}
   
-  LANTERN_API void* (LANTERN_PTR _lantern_load_state_dict) (const char * path);
-  HOST_API void * lantern_load_state_dict (const char * path)
+  LANTERN_API void* (LANTERN_PTR _lantern_load_state_dict) (void* path, bool legacy_stream);
+  HOST_API void * lantern_load_state_dict (void* path, bool legacy_stream)
   {
     LANTERN_CHECK_LOADED
-    void * ret = _lantern_load_state_dict(path);
+    void * ret = _lantern_load_state_dict(path, legacy_stream);
     LANTERN_HOST_HANDLER return ret;
   }
 

--- a/man/load_state_dict.Rd
+++ b/man/load_state_dict.Rd
@@ -4,10 +4,15 @@
 \alias{load_state_dict}
 \title{Load a state dict file}
 \usage{
-load_state_dict(path)
+load_state_dict(path, ..., legacy_stream = FALSE)
 }
 \arguments{
 \item{path}{to the state dict file}
+
+\item{...}{additional arguments that are currently not used.}
+
+\item{legacy_stream}{if \code{TRUE} then the state dict is loaded using a
+a legacy way of handling streams.}
 }
 \value{
 a named list of tensors.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -47971,13 +47971,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_load_state_dict
-Rcpp::List cpp_load_state_dict(std::string path);
-RcppExport SEXP _torch_cpp_load_state_dict(SEXP pathSEXP) {
+Rcpp::List cpp_load_state_dict(torch::string path, bool legacy_stream);
+RcppExport SEXP _torch_cpp_load_state_dict(SEXP pathSEXP, SEXP legacy_streamSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_load_state_dict(path));
+    Rcpp::traits::input_parameter< torch::string >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< bool >::type legacy_stream(legacy_streamSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_load_state_dict(path, legacy_stream));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -52480,7 +52481,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_torch_reduction_sum", (DL_FUNC) &_torch_cpp_torch_reduction_sum, 0},
     {"_torch_cpp_tensor_save", (DL_FUNC) &_torch_cpp_tensor_save, 2},
     {"_torch_cpp_tensor_load", (DL_FUNC) &_torch_cpp_tensor_load, 3},
-    {"_torch_cpp_load_state_dict", (DL_FUNC) &_torch_cpp_load_state_dict, 1},
+    {"_torch_cpp_load_state_dict", (DL_FUNC) &_torch_cpp_load_state_dict, 2},
     {"_torch_cpp_torch_scalar", (DL_FUNC) &_torch_cpp_torch_scalar, 1},
     {"_torch_cpp_torch_scalar_dtype", (DL_FUNC) &_torch_cpp_torch_scalar_dtype, 1},
     {"_torch_cpp_torch_scalar_to_int", (DL_FUNC) &_torch_cpp_torch_scalar_to_int, 1},

--- a/src/lantern/include/lantern/lantern.h
+++ b/src/lantern/include/lantern/lantern.h
@@ -589,11 +589,11 @@ LANTERN_OPTIONAL_DECLS(string_view)
   LANTERN_API void*(LANTERN_PTR _lantern_jit_execute)(void* name, void* stack);
   HOST_API void* lantern_jit_execute(void* name, void* stack) {LANTERN_CHECK_LOADED void* ret = _lantern_jit_execute(name, stack); LANTERN_HOST_HANDLER return ret;}
   
-  LANTERN_API void* (LANTERN_PTR _lantern_load_state_dict) (const char * path);
-  HOST_API void * lantern_load_state_dict (const char * path)
+  LANTERN_API void* (LANTERN_PTR _lantern_load_state_dict) (void* path, bool legacy_stream);
+  HOST_API void * lantern_load_state_dict (void* path, bool legacy_stream)
   {
     LANTERN_CHECK_LOADED
-    void * ret = _lantern_load_state_dict(path);
+    void * ret = _lantern_load_state_dict(path, legacy_stream);
     LANTERN_HOST_HANDLER return ret;
   }
 

--- a/src/lantern/src/Pickler.cpp
+++ b/src/lantern/src/Pickler.cpp
@@ -1451,7 +1451,19 @@ IValue pickle_load2(const std::vector<char>& data) {
       "pickle_load not supported on mobile "
       "(see https://github.com/pytorch/pytorch/pull/30108)");
 #endif
-};
+}
+
+IValue pickle_load3(std::string path) {
+  caffe2::serialize::PyTorchStreamReader reader(path);
+  return readArchiveAndTensors(
+    "data",
+    /*pickle_prefix=*/"",
+    /*tensor_prefix=*/"",
+    /*type_resolver=*/c10::nullopt,
+    /*obj_loader=*/c10::nullopt,
+    /*device=*/c10::nullopt,
+    reader);
+}
 
 IValue unpickle(
     std::function<size_t(char*, size_t)> reader,

--- a/src/lantern/src/Save.cpp
+++ b/src/lantern/src/Save.cpp
@@ -69,13 +69,22 @@ void _lantern_test_print(void* x) {
 
 namespace torch::jit {
 IValue pickle_load2(const std::vector<char>& data);
+IValue pickle_load3(std::string path);
 }
-void* _lantern_load_state_dict(const char* path) {
+void* _lantern_load_state_dict(void* path, bool legacy_stream) {
   LANTERN_FUNCTION_START
-  std::ifstream file(path, std::ios::binary);
-  std::vector<char> data((std::istreambuf_iterator<char>(file)),
-                         std::istreambuf_iterator<char>());
-  torch::IValue ivalue = torch::jit::pickle_load2(data);
+  auto path_ = from_raw::string(path);
+  
+  torch::IValue ivalue;
+  if (legacy_stream) {
+    std::ifstream file(path_.c_str(), std::ios::binary);
+    std::vector<char> data((std::istreambuf_iterator<char>(file)),
+                           std::istreambuf_iterator<char>());
+    ivalue = torch::jit::pickle_load2(data);
+  } else {
+    ivalue = torch::jit::pickle_load3(path_);
+  }
+  
   return make_raw::IValue(ivalue);
   LANTERN_FUNCTION_END
 }

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -31,8 +31,8 @@ XPtrTorchTensor cpp_tensor_load(SEXP input, XPtrTorchOptionalDevice device, bool
 }
 
 // [[Rcpp::export]]
-Rcpp::List cpp_load_state_dict(std::string path) {
-  XPtrTorchIValue v = lantern_load_state_dict(path.c_str());
+Rcpp::List cpp_load_state_dict(torch::string path, bool legacy_stream = false) {
+  XPtrTorchIValue v = lantern_load_state_dict(path.get(), legacy_stream);
 
   XPtrTorchTensorList values = lantern_get_state_dict_values(v.get());
 

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -157,7 +157,7 @@ test_that("load a state dict created in python", {
   # value = {'ones': ones, 'twos': twos}
   # torch.save(value, "assets/state_dict.pth", _use_new_zipfile_serialization=True)
 
-  dict <- load_state_dict("assets/state_dict.pth")
+  dict <- load_state_dict(test_path("assets/state_dict.pth"))
   expect_equal(names(dict), c("ones", "twos"))
   expect_equal_to_tensor(dict$ones, torch_ones(3, 5))
   expect_equal_to_tensor(dict$twos, torch_ones(3, 5) * 2)


### PR DESCRIPTION
Add another version of pickle_read that supports reading directly from paths, making it faster for reasonable sized files and use less memory.

The old option is kept under `legacy_stream` argument, so it's easy to go back if required for some use cases.