### PR TITLE
Fix polyglot file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Imports:
     glue,
     ellipsis,
     desc,
-    safetensors
+    safetensors,
+    jsonlite
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Suggests:


### PR DESCRIPTION
Turns out that polyglot files are not accepted, thus we store the serialized R object into a byte tensor so `torch_save` output continues to be a valid safetensors file.

Follow up for #1071 