### PR TITLE
better handling of partial argument matching

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,5 @@
+old_opts = options(
+  warnPartialMatchArgs = TRUE,
+  warnPartialMatchAttr = TRUE,
+  warnPartialMatchDollar = TRUE
+)

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,0 +1,1 @@
+options(old_opts)


### PR DESCRIPTION
In the CI of mlr3torch I noticed the partial argument matching of `con` to `connection` in `serialize()`.
This is fixed in this PR and additionally, I added some option setting during the tests to warn when something like this happens (let's see what comes out in the CI or whether you think this is a valuable setting). 