### PR TITLE
Raise error when comparing a device with something that's not a dtype.

### DIFF
--- a/R/dtype.R
+++ b/R/dtype.R
@@ -147,6 +147,9 @@ torch_qint32 <- function() torch_dtype$new(cpp_torch_qint32())
 
 #' @export
 `==.torch_dtype` <- function(e1, e2) {
+  if (!is_torch_dtype(e1) || !is_torch_dtype(e2)) {
+    runtime_error("One of the objects is not a dtype. Comparison is not possible.")
+  }
   cpp_dtype_to_string(e1$ptr) == cpp_dtype_to_string(e2$ptr)
 }
 

--- a/tests/testthat/test-dtype.R
+++ b/tests/testthat/test-dtype.R
@@ -66,3 +66,12 @@ test_that("can set select devices using strings", {
   }
   
 })
+
+test_that("error when comparing dtypes", {
+  
+  expect_error(
+    NULL == torch_float64(),
+    "not a dtype"
+  )
+  
+})


### PR DESCRIPTION
Fixes #1083 