### PR TITLE
Solved `out_features` typo in `nn_linear`.

### DIFF
--- a/R/nn-linear.R
+++ b/R/nn-linear.R
@@ -57,8 +57,8 @@ nn_identity <- nn_module(
 nn_linear <- nn_module(
   "nn_linear",
   initialize = function(in_features, out_features, bias = TRUE) {
-    self$in_features <- in_features
-    self$out_feature <- out_features
+    self$in_features  <- in_features
+    self$out_features <- out_features
 
     self$weight <- nn_parameter(torch_empty(out_features, in_features))
     if (bias) {

--- a/tests/testthat/test-nn.R
+++ b/tests/testthat/test-nn.R
@@ -311,7 +311,7 @@ test_that("$<-  works for instances", {
   expect_s3_class(model, "nn_module")
   model$mymodule <- nn_linear(2, 2)
   expect_s3_class(model, "nn_module")
-  expect_equal(model$mymodule$out_feature, 2)
+  expect_equal(model$mymodule$out_features, 2)
   model$new_module <- nn_linear(5, 5)
   expect_s3_class(model, "nn_module")
 
@@ -333,7 +333,7 @@ test_that("[[<- works for instances", {
   expect_s3_class(model, "nn_module")
   model[["mymodule"]] <- nn_linear(2, 2)
   expect_s3_class(model, "nn_module")
-  expect_equal(model$mymodule$out_feature, 2)
+  expect_equal(model$mymodule$out_features, 2)
   model[["new_module"]] <- nn_linear(5, 5)
   expect_s3_class(model, "nn_module")
 


### PR DESCRIPTION
The public member of `nn_linear` for the output features should be called `out_features` instead of `out_feature` (s was missing). Solved the typo and updated `test-nn.R` to not fail with the new name.