### PR TITLE
Added information about m1 GPU

### DIFF
--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -63,7 +63,15 @@ If you have followed default installation locations we will detect that you have
 
 ### CPU
 
-We only support CPU builds of torch on MacOS. On MacOS you can install torch with:
+We support CPU builds of torch on MacOS. On MacOS you can install torch with:
+
+```{r, eval = FALSE}
+install.packages("torch")
+```
+
+### GPU
+
+On Apple Silicon architecture we support GPU through MPS:
 
 ```{r, eval = FALSE}
 install.packages("torch")


### PR DESCRIPTION
Based on messages from issues, it seems that GPU is supported on Apple Silicon through MPS (Metal Performance Shaders). Same approach is used in PyTorch.

I think it should be presented in the documentation.