### PR TITLE
fix(Tensor): cloning preserves attributes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Authors@R: c(
     person("Christophe", "Regouby", role = c("ctb")),
     person("Krzysztof", "Joachimiak", role = c("ctb")),
     person("Hamada S.", "Badr", role = c("ctb")),
+    person("Sebastian", "Fischer", role = c("ctb")),
     person(family = "RStudio", role = c("cph"))
     )
 Description: Provides functionality to define and train neural networks similar to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # torch (development version)
 
-- Make sure deep cloning preserve state dict attributes. (#1129)
+- Make sure deep cloning preserve class attributes. (#1129)
 
 # torch 0.12.0
 

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -71,27 +71,27 @@ Tensor <- R7Class(
     },
     to = function(dtype = NULL, device = NULL, other = NULL, non_blocking = FALSE,
                   copy = FALSE, memory_format = NULL) {
-      
+
       has_device <- !is.null(device)
       has_dtype <- !is.null(dtype)
       has_other <- !is.null(other)
-      
+
       if (has_other) {
         # can't have device and dtype
         if (has_device || has_dtype) {
           cli::cli_abort("Had {.arg other} but {.arg device} or {.arg dtype} are non {.val NULL}")
         }
-        
+
         return(private$`_to`(other = other, non_blocking = non_blocking, copy = copy))
       }
-      
+
       if (!has_dtype) {
         dtype <- self$dtype
       }
-      
+
       if (has_device) {
         private$`_to`(
-          dtype = dtype, 
+          dtype = dtype,
           device = device,
           non_blocking = non_blocking,
           copy = copy,
@@ -288,6 +288,11 @@ Tensor <- R7Class(
     },
     half = function() {
       self$to(dtype=torch_half())
+    },
+    clone2 = function() {
+      x <- torch_clone(self)
+      attributes(x) <- attributes(self)
+      return(x)
     }
   ),
   active = list(
@@ -383,7 +388,7 @@ as.matrix.torch_tensor <- function(x, ...) {
 as_array_impl <- function(x) {
   # move tensor to cpu before copying to R
   x <- x$cpu()
-  
+
   if (x$is_complex()) {
     out <- complex(
       real = as.array(x$real),
@@ -392,7 +397,7 @@ as_array_impl <- function(x) {
     dim(out) <- dim(x)
     return(out)
   }
-  
+
   a <- cpp_as_array(x)
 
   if (length(a$dim) <= 1L) {
@@ -479,13 +484,13 @@ Tensor$set("active", "ptr", function() {
 
 tensor_to_complex <- function(x) {
   torch_complex(
-    torch_tensor(Re(x), dtype = torch_double()), 
+    torch_tensor(Re(x), dtype = torch_double()),
     torch_tensor(Im(x), dtype = torch_double())
   )
 }
 
 #' Creates a tensor from a buffer of memory
-#' 
+#'
 #' It creates a tensor without taking ownership of the memory it points to.
 #' You must call `clone` if you want to copy the memory over a new tensor.
 #'

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -408,14 +408,14 @@ test_that("print complex tensors", {
   skip_on_os("linux")
   x <- torch_complex(torch_randn(10), torch_randn(10))
   expect_snapshot(
-    print(x)  
+    print(x)
   )
-  
+
   x$requires_grad_(TRUE)
   expect_snapshot(
     print(x)
   )
-  
+
   y <- 2*x
   expect_snapshot(
     print(y)
@@ -423,52 +423,52 @@ test_that("print complex tensors", {
 })
 
 test_that("complex tensors modifications and acessing", {
-  
+
   real <- torch_randn(10, 10)
   imag <- torch_randn(10, 10)
   x <- torch_complex(real, imag)
-  
+
   expect_equal_to_tensor(x$real, real)
   expect_equal_to_tensor(x$imag, imag)
-  
+
   real <- torch_randn(10, 10)
   imag <- torch_randn(10, 10)
   x$real <- real
   x$imag <- imag
-  
+
   expect_equal_to_tensor(x$real, real)
   expect_equal_to_tensor(x$imag, imag)
-  
+
 })
 
 test_that("create complex from and to R", {
-  
+
   x <- complex(real = c(0, 1), imaginary = c(1, 1))
   y <- torch_tensor(x)
-  
+
   expect_equal_to_r(y$imag, Im(x))
   expect_equal_to_r(y$real, Re(x))
   expect_true(y$dtype == torch_cfloat())
-  
+
   x <- complex(real = runif(1), imaginary = runif(1))
   y <- torch_tensor(x, dtype = torch_cdouble())
-  
+
   expect_equal_to_r(y$imag, Im(x))
   expect_equal_to_r(y$real, Re(x))
   expect_true(y$dtype == torch_cdouble())
-  
+
   x <- torch_complex(torch_randn(10, 10), torch_randn(10, 10))
   y <- as.array(x)
   z <- torch_tensor(y)
-  
+
   expect_true(torch_allclose(x, z))
-  
+
   x <- torch_complex(1, 1)
   y <- as.array(x)
   z <- torch_tensor(y)
   expect_true(torch_allclose(x, z))
   expect_equal(as.complex(x), complex(real = 1,imaginary = 1))
-  
+
 })
 
 test_that("expand works", {
@@ -496,22 +496,22 @@ test_that("is_sparse works", {
 })
 
 test_that("can make a byte tensor from a raw vector", {
-  
+
   x <- charToRaw("hello world")
   ten <- torch_tensor(x)
-  
+
   expect_equal(ten$dtype$.type(), "Byte")
   expect_equal(length(x), length(ten))
-  
+
   expect_equal(as.array(ten), x)
   expect_equal(rawToChar(as.array(ten)), "hello world")
 })
 
 test_that("to can change both device and dtype", {
-  
+
   x <- torch_randn(10, 10)
   y <- x$to(dtype = "double", device = "meta")
-  
+
   expect_true(y$dtype == torch_double())
   expect_true(y$device == torch_device("meta"))
 })
@@ -546,6 +546,28 @@ test_that("can copy a mps tensor", {
   x <- array(runif(100), dim = c(10, 10))
   y <- torch_tensor(x, device="mps")
   x_ <- as.array(y)
-  
+
   expect_true(all.equal(x, x_, tolerance = 1e-5))
+})
+
+test_that("cloning works and preserves attributes", {
+  # buffer
+  x_buf <- nn_buffer(torch_tensor(1))
+  x_buf_clone = x_buf$clone2()
+  expect_equal(attributes(x_buf), attributes(x_buf_clone))
+  x_buf[1] = 2
+  expect_false(torch_equal(x_buf, x_buf_clone))
+
+  x_param <- nn_parameter(torch_tensor(1))
+  x_param_clone = x_param$clone2()
+  expect_equal(attributes(x_param), attributes(x_param_clone))
+  x_param$requires_grad_(FALSE) # otherwise we cannot modify tensor in-place
+  x_param[1] = 2
+  expect_false(torch_equal(x_param, x_param_clone))
+
+  x <- torch_tensor(1)
+  x_clone <- x$clone2()
+  expect_equal(attributes(x_clone), attributes(x))
+  x[1] <- 2
+  expect_false(torch_equal(x_clone, x))
 })


### PR DESCRIPTION
Addresses https://github.com/mlverse/torch/issues/1126, where you offered to take care of the renaming. 
I.e. the `$clone2()` method should just be renamed to `$clone()`, which currently has no effect, as the `find_method()` function (iirc) still finds the `torch_clone()` function that is auto-generated.