### PR TITLE
feat: comparison of torch tensors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Imports:
     desc,
     safetensors (>= 0.1.1),
     jsonlite
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 Suggests:
     testthat (>= 3.0.0),
@@ -65,6 +65,7 @@ Collate:
     'backends.R'
     'call_torch_function.R'
     'codegen-utils.R'
+    'compare.R'
     'compat-purrr.R'
     'compilation_unit.R'
     'conditions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # torch (development version)
 
 - Make sure deep cloning preserve state dict attributes. (#1129)
+- A `compare_proxy` method for the `torch_tensor` type was added
+  it allows to compare torch tensor's using `testthat::expect_equal()`.
 
 # torch 0.12.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Make sure deep cloning preserve state dict attributes. (#1129)
 - A `compare_proxy` method for the `torch_tensor` type was added
-  it allows to compare torch tensor's using `testthat::expect_equal()`.
+  it allows to compare torch tensors using `testthat::expect_equal()`.
 - Converting torch tensor to R array works when tensor has 'cuda' device (#1130)
 
 # torch 0.12.0

--- a/R/compare.R
+++ b/R/compare.R
@@ -1,0 +1,34 @@
+compare_proxy.torch_tensor <- function(x, path) {
+  # we don't include the grad_fn because it should change after cloning a tensor (BackwardClone)
+  list(
+    object = list(
+      x = torch::as_array(x),
+      device = as.character(x$device),
+      requires_grad = x$requires_grad,
+      grad_fn = x$grad_fn
+    ),
+    path = path
+  )
+}
+
+# shamelessly copied from: https://github.com/tidyverse/readr/blob/e529cb2775f1b52a0dfa30dabc9f8e0014aa77e6/R/zzz.R
+register_s3_method <- function(pkg, generic, class, fun = NULL) {
+  if (is.null(fun)) {
+    fun <- get(paste0(generic, ".", class), envir = parent.frame())
+  } else {
+    stopifnot(is.function(fun))
+  }
+
+  if (pkg %in% loadedNamespaces()) {
+    registerS3method(generic, class, fun, envir = asNamespace(pkg))
+  }
+
+  # Always register hook in case package is later unloaded & reloaded
+  setHook(
+    packageEvent(pkg, "onLoad"),
+    function(...) {
+      registerS3method(generic, class, fun, envir = asNamespace(pkg))
+    }
+  )
+}
+

--- a/R/compare.R
+++ b/R/compare.R
@@ -1,5 +1,4 @@
 compare_proxy.torch_tensor <- function(x, path) {
-  # we don't include the grad_fn because it should change after cloning a tensor (BackwardClone)
   list(
     object = list(
       x = torch::as_array(x),

--- a/R/package.R
+++ b/R/package.R
@@ -11,24 +11,25 @@ globalVariables(c("..", "self", "private", "N"))
 }
 
 .onLoad <- function(libname, pkgname) {
+  register_s3_method("waldo", "compare_proxy", "torch_tensor")
   cpp_torch_namespace__store_main_thread_id()
 
   install_success <- TRUE
-  
+
   is_interactive <- interactive() ||
     "JPY_PARENT_PID" %in% names(Sys.getenv()) ||
     identical(getOption("jupyter.in_kernel"), TRUE)
-  
-  # we only autoinstall if it has not explicitly disabled by setting 
+
+  # we only autoinstall if it has not explicitly disabled by setting
   # TORCH_INSTALL = 0
   autoinstall <- is_interactive && (Sys.getenv("TORCH_INSTALL", unset = 2) != 0)
-  
+
   # We can also auto install if TORCH_INSTALL is requested with TORCH_INSTALL=1
   autoinstall <- autoinstall || (Sys.getenv("TORCH_INSTALL", unset = 2) == "1")
-  
+
   # we only autoinstall if installation doesn't yet exist.
   autoinstall <- autoinstall && (!torch_is_installed())
-  
+
   if (autoinstall) {
     install_success <- tryCatch(
       {
@@ -37,8 +38,8 @@ globalVariables(c("..", "self", "private", "N"))
         # in interactive environments we want to ask the user for permission to
         # download and install stuff. That's not necessary otherwise because the
         # user has explicitly asked for installation with `TORCH_INSTALL=1`.
-        if (is_interactive) { 
-          get_confirmation() # this will error of response is not true.  
+        if (is_interactive) {
+          get_confirmation() # this will error of response is not true.
         }
         install_torch(.inform_restart = FALSE)
         TRUE

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -51,6 +51,7 @@ test_that("grad_fn is respected", {
 
 test_that("compare tensors using cuda", {
   skip_if_cuda_not_available()
+  testthat::local_edition(3)
 
   expect_failure(expect_equal(
     torch_tensor(1)$cuda(),

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -1,0 +1,59 @@
+test_that("comparison takes requires_grad into account", {
+  testthat::local_edition(3)
+  expect_equal(
+    torch_tensor(1)$requires_grad_(FALSE),
+    torch_tensor(1)$requires_grad_(FALSE)
+  )
+  expect_equal(
+    torch_tensor(1)$requires_grad_(TRUE),
+    torch_tensor(1)$requires_grad_(TRUE)
+  )
+  expect_failure(expect_equal(
+    torch_tensor(1)$requires_grad_(FALSE),
+    torch_tensor(1)$requires_grad_(TRUE)
+  ))
+})
+
+test_that("comparison takes tensor's value into account", {
+  testthat::local_edition(3)
+  expect_failure(expect_equal(
+    torch_tensor(1),
+    torch_tensor(2)
+  ))
+})
+
+test_that("comparison takes tensor's dimension into account", {
+  testthat::local_edition(3)
+  expect_failure(expect_equal(
+    torch_tensor(1)$reshape(c(1, 1)),
+    torch_tensor(1)$reshape(1)
+  ))
+})
+
+test_that("grad_fn is respected", {
+  testthat::local_edition(3)
+  x = torch_tensor(1)$requires_grad_(TRUE)
+  # grad_fn is changed after cloning
+  expect_failure(expect_equal(
+    x,
+    x$clone()
+  ))
+
+  # without requires_grad, grad_fn is not changed
+
+  x = torch_tensor(1)
+  # grad_fn is changed
+  expect_equal(
+    x,
+    x$clone()
+  )
+})
+
+test_that("compare tensors using cuda", {
+  skip_if_cuda_not_available()
+
+  expect_failure(expect_equal(
+    torch_tensor(1)$cuda(),
+    torch_tensor(1)$cpu()
+  ))
+})

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -1,4 +1,4 @@
-skip_if(getRversion() <= "0.4.0")
+skip_if(getRversion() <= "4.0.0")
 
 test_that("comparison takes requires_grad into account", {
   testthat::local_edition(3)

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -1,3 +1,5 @@
+skip_if(getRversion() <= "0.4.0")
+
 test_that("comparison takes requires_grad into account", {
   testthat::local_edition(3)
   expect_equal(


### PR DESCRIPTION
I did not create a PR in waldo, because I think this method should be under full control of the torch package. I "hacked" it in, so waldo does not become a hard dependency here. 