### PR TITLE
Use AWS S3 to store torch binaries

### DIFF
--- a/.github/actions/install-cudnn/cudnn-url.txt
+++ b/.github/actions/install-cudnn/cudnn-url.txt
@@ -1,8 +1,8 @@
-windows 11.3    https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-11.3-windows-x64-v8.2.1.32.zip
+windows 11.3    https://torch-cdn.mlverse.org/cudnn/cudnn-11.3-windows-x64-v8.2.1.32.zip
 windows 11.7    https://developer.download.nvidia.com/compute/redist/cudnn/v8.5.0/local_installers/11.7/cudnn-windows-x86_64-8.5.0.96_cuda11-archive.zip
 windows 11.8    https://developer.download.nvidia.com/compute/redist/cudnn/v8.7.0/local_installers/11.8/cudnn-windows-x86_64-8.7.0.84_cuda11-archive.zip
-linux   11.3    https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-11.3-linux-x64-v8.2.1.32.tgz
-linux   11.6    https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tgz
-linux   10.2    https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-10.2-linux-x64-v7.6.5.32.tgz
-linux   11.7    https://storage.googleapis.com/torch-lantern-builds/cudnn/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
+linux   11.3    https://torch-cdn.mlverse.org/cudnn/cudnn-11.3-linux-x64-v8.2.1.32.tgz
+linux   11.6    https://torch-cdn.mlverse.org/cudnn/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tgz
+linux   10.2    https://torch-cdn.mlverse.org/cudnn/cudnn-10.2-linux-x64-v7.6.5.32.tgz
+linux   11.7    https://torch-cdn.mlverse.org/cudnn/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
 linux   11.8    https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.0.131_cuda11-archive.tar.xz

--- a/.github/actions/upload-dir-to-s3/action.yml
+++ b/.github/actions/upload-dir-to-s3/action.yml
@@ -1,0 +1,46 @@
+name: "Uploads packaging artifacts to S3"
+description: "Uploads lantern artifacts to S3"
+inputs:
+  path:
+    required: true
+    description: "the dir path that should be uploaded."
+  destination:
+    required: true
+    description: "the s3 destination of the files"
+  aws_role_to_assume:
+    required: true
+    description: "Role ARN to be assumed"
+  aws_region:
+    required: true
+    description: "Region id to be used"
+
+runs:
+  using: composite
+  steps:
+
+    - id: 'linux-install'
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt install -y unzip
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+      shell: bash
+
+    - id: 'macos-install'
+      if: runner.os == 'macOS'
+      run: |
+        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+        sudo installer -pkg AWSCLIV2.pkg -target /
+      shell: bash
+
+    - id: 'auth'
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: ${{ inputs.aws_role_to_assume }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - id: 'upload-file'
+      run: |
+        aws s3 cp ${{ inputs.path }} ${{ inputs.destination }} --recursive
+      shell: bash

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -18,6 +18,7 @@ runs:
     - id: 'linux-install'
       if: runner.os == 'Linux'
       run: |
+        sudo apt install -y unzip
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
         unzip awscliv2.zip
         sudo ./aws/install

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -15,6 +15,9 @@ runs:
   using: composite
   steps:
 
+    - id: install-aws-cli
+      uses: unfor19/install-aws-cli-action@v1
+
     - id: 'auth'
       uses: aws-actions/configure-aws-credentials@master
       with:

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -15,10 +15,20 @@ runs:
   using: composite
   steps:
 
-    - id: install-aws-cli
-      uses: unfor19/install-aws-cli-action@v1
-      with:
-          version: 2
+    - id: 'linux-install'
+      if: runner.os == 'Linux'
+      run: |
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+      shell: bash
+
+    - id: 'macos-install'
+      if: runner.os == 'macOS'
+      run: |
+        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+        sudo installer -pkg AWSCLIV2.pkg -target /
+      shell: bash
 
     - id: 'auth'
       uses: aws-actions/configure-aws-credentials@master

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -1,0 +1,24 @@
+name: "Uploads lantern artifacts to S3"
+description: "Uploads lantern artifacts to S3"
+inputs:
+  fname:
+     required: true
+     description: "the filename that should be uploaded."
+
+runs:
+  using: composite
+  steps:
+
+    - id: 'auth'
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - id: 'upload-file'
+      run: |
+        aws s3 cp src/lantern/build/${{ inputs.fname }} s3://torch-binaries/binaries/${{ github.sha }}/${{ inputs.fname }}
+
+    - id: 'upload-latest'
+      run: |
+        aws s3 cp src/lantern/build/${{ inputs.fname }} s3://torch-binaries/binaries/${{ github.ref }}/latest/${{ inputs.fname }}

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -24,7 +24,9 @@ runs:
     - id: 'upload-file'
       run: |
         aws s3 cp src/lantern/build/${{ inputs.fname }} s3://torch-binaries/binaries/${{ github.sha }}/${{ inputs.fname }}
+      shell: bash
 
     - id: 'upload-latest'
       run: |
         aws s3 cp src/lantern/build/${{ inputs.fname }} s3://torch-binaries/binaries/${{ github.ref }}/latest/${{ inputs.fname }}
+      shell: bash

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -17,6 +17,8 @@ runs:
 
     - id: install-aws-cli
       uses: unfor19/install-aws-cli-action@v1
+      with:
+          version: 2
 
     - id: 'auth'
       uses: aws-actions/configure-aws-credentials@master

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -2,8 +2,14 @@ name: "Uploads lantern artifacts to S3"
 description: "Uploads lantern artifacts to S3"
 inputs:
   fname:
-     required: true
-     description: "the filename that should be uploaded."
+    required: true
+    description: "the filename that should be uploaded."
+  aws_role_to_assume:
+    required: true
+    description: "Role ARN to be assumed"
+  aws_region:
+    required: true
+    description: "Region id to be used"
 
 runs:
   using: composite
@@ -12,8 +18,8 @@ runs:
     - id: 'auth'
       uses: aws-actions/configure-aws-credentials@master
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        aws-region: ${{ secrets.AWS_REGION }}
+        role-to-assume: ${{ inputs.aws_role_to_assume }}
+        aws-region: ${{ inputs.aws_region }}
 
     - id: 'upload-file'
       run: |

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -115,5 +115,11 @@ jobs:
         with:
           fname: ${{ steps.build.outputs.fname }}
           gcp_credential: ${{ secrets.GCP_APPLICATION_CREDENTIALS }}
+      
+      - id: 's3'
+        if: ${{ github.workflow != 'Test' || github.event_name != 'pull_request'}}
+        uses: ./.github/actions/upload-s3
+        with:
+          fname: ${{ steps.build.outputs.fname }}
 
       

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
     container: ${{ matrix.container }}
     name: "os:${{matrix.config.os}} | v:${{matrix.config.version}} (pre-cxx11: ${{matrix.precxx11abi }})"
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -108,13 +108,6 @@ jobs:
         with:
           name: lantern
           path: 'src/lantern/build/${{ steps.build.outputs.fname }}'
-
-      - id: 'gcs'
-        if: ${{ github.workflow != 'Test' || github.event_name != 'pull_request'}}
-        uses: ./.github/actions/upload-gcs
-        with:
-          fname: ${{ steps.build.outputs.fname }}
-          gcp_credential: ${{ secrets.GCP_APPLICATION_CREDENTIALS }}
       
       - id: 's3'
         if: ${{ github.workflow != 'Test' || github.event_name != 'pull_request'}}

--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -121,5 +121,7 @@ jobs:
         uses: ./.github/actions/upload-s3
         with:
           fname: ${{ steps.build.outputs.fname }}
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
 
       

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
       - master
       - main
       - "cran/**"
+      - "s3"
   pull_request:
   schedule:
     - cron: "0 1 * * *"

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - cran/*
       - packaging3
+      - s3
   schedule:
     - cron: "0 2 * * *"
   
@@ -109,4 +110,10 @@ jobs:
           path: "../binaries"
           destination: 'torch-lantern-builds/packages/${{ matrix.config.version }}/${{ steps.build.outputs.pkg_version }}/'
           parent: false
+
+      - id: 'upload-s3'
+        uses: ./.github/actions/upload-dir-to-s3
+        with:
+          path: "../binaries"
+          destination: 's3://torch-binaries/packages/${{ matrix.config.version }}/${{ steps.build.outputs.pkg_version }}/'
       

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -102,18 +102,6 @@ jobs:
           cat("pkg_version=", desc::desc_get("Version"), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep="")
         shell: Rscript {0}
         
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{ secrets.GCP_APPLICATION_CREDENTIALS }}
-
-      - id: 'upload-file'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: "../binaries"
-          destination: 'torch-lantern-builds/packages/${{ matrix.config.version }}/${{ steps.build.outputs.pkg_version }}/'
-          parent: false
-
       - id: 'upload-s3'
         uses: ./.github/actions/upload-dir-to-s3
         with:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -116,4 +116,6 @@ jobs:
         with:
           path: "../binaries"
           destination: 's3://torch-binaries/packages/${{ matrix.config.version }}/${{ steps.build.outputs.pkg_version }}/'
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
       

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -12,6 +12,9 @@ on:
     - cron: "0 2 * * *"
   
 jobs:
+  permissions:
+      id-token: write
+      contents: read
   binaries:
     runs-on: ${{ matrix.config.runner }}
     container: ${{ matrix.container }}

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -12,10 +12,10 @@ on:
     - cron: "0 2 * * *"
   
 jobs:
-  permissions:
+  binaries:
+    permissions:
       id-token: write
       contents: read
-  binaries:
     runs-on: ${{ matrix.config.runner }}
     container: ${{ matrix.container }}
     strategy:

--- a/R/install.R
+++ b/R/install.R
@@ -232,7 +232,7 @@ lantern_url <- function() {
   base_url <- Sys.getenv("LANTERN_BASE_URL", "")
 
   if (!nzchar(base_url)) {
-    base_url <- "https://storage.googleapis.com/torch-lantern-builds/binaries/"
+    base_url <- "https://torch-cdn.mlverse.org/binaries/"
   
     remote_sha <- Sys.getenv("TORCH_COMMIT_SHA", "")
     if (remote_sha == "none") {

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -177,7 +177,7 @@ test_that("Can load a torch v0.2.1 model", {
   dest <- testthat::test_path("assets/model-v0.2.1.pt")
   if (!file.exists(dest)) {
     download.file(
-      "https://storage.googleapis.com/torch-lantern-builds/testing-models/v0.2.1.pt", 
+      "https://torch-cdn.mlverse.org/testing-models/v0.2.1.pt", 
       destfile = dest, 
       mode = "wb"
     )  
@@ -197,7 +197,7 @@ test_that("Can load a v0.10.0 model", {
   dest <- testthat::test_path("assets/model-v0.10.0.pt")
   if (!file.exists(dest)) {
     download.file(
-      "https://storage.googleapis.com/torch-lantern-builds/testing-models/v0.10.0.pt", 
+      "https://torch-cdn.mlverse.org/testing-models/v0.10.0.pt", 
       destfile = dest, 
       mode = "wb"
     )  

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -128,7 +128,7 @@ options(timeout = 600) # increasing timeout is recommended since we will be down
 kind <- "cu118"
 version <- available.packages()["torch","Version"]
 options(repos = c(
-  torch = sprintf("https://storage.googleapis.com/torch-lantern-builds/packages/%s/%s/", kind, version),
+  torch = sprintf("https://torch-cdn.mlverse.org/packages/%s/%s/", kind, version),
   CRAN = "https://cloud.r-project.org" # or any other from which you want to install the other R dependencies.
 ))
 install.packages("torch")

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -173,3 +173,14 @@ Sys.setenv(TORCH_URL="/tmp/libtorch-v1.13.1.zip")
 Sys.setenv(LANTERN_URL="/tmp/lantern-0.9.1.9001+cpu+arm64-Darwin.zip")
 torch::install_torch()
 ```
+
+### Installing older versions
+
+As of v0.13.0 torch shifted from using Google Cloud Storage service to AWS S3 as the storage service for the required Lantern binaries.
+
+We will keep the files in the GCS bucket for as long as possible, but we might need to remove them at some point in time.
+Those files have been backed up in the new AWS S3 bucket using the same file structure, so if torch tries to download some from a URL starting with
+`https://storage.googleapis.com/torch-lantern-builds`, you should now replace it with `https://torch-cdn.mlverse.org`.
+
+For torch versions between v0.10.0 and v0.12.0 (both included), you should be able to set the environment variable `LANTERN_BASE_URL=https://torch-cdn.mlverse.org/binaries/` to point to the new address of the binaries.
+For older versions of torch, you might need to manually download the file from the new address and extract it to the expected `TORCH_HOME` directory. Feel free to open an issue on GitHub if you need help with this.


### PR DESCRIPTION
We are currently using GCS to store and distribute binaries, but that is not ideal.

This PR moves the infra to an S3 bucket to store the binaries with a CloudFront distribution for downloading the binaries.
This makes our infra easier to maintain and also easier to observe.
