### PR TITLE
Use rlang instead of ellipsis for checking dots.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     Rcpp,
     R6,
     withr,
-    rlang,
+    rlang (>= 1.0.0),
     methods,
     utils,
     stats,
@@ -41,7 +41,6 @@ Imports:
     callr,
     cli (>= 3.0.0),
     glue,
-    ellipsis,
     desc,
     safetensors (>= 0.1.1),
     jsonlite

--- a/R/generator.R
+++ b/R/generator.R
@@ -99,7 +99,7 @@ local_torch_manual_seed <- function(seed, .env = parent.frame()) {
 #' @describeIn torch_manual_seed A with context to change the seed during the function execution.
 #' @export
 with_torch_manual_seed <- function(code, ..., seed) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   local_torch_manual_seed(seed)
   force(code)
 }

--- a/R/linalg.R
+++ b/R/linalg.R
@@ -264,7 +264,7 @@ linalg_cond <- function(A, p = NULL) {
 #' @family linalg
 #' @export
 linalg_matrix_rank <- function(A, ..., atol = NULL, rtol = NULL, tol = NULL, hermitian = FALSE) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   if (!is.null(tol)) {
     warn("`tol` argument is deprecated in favor of `atol` and `rtol`.")
     atol <- tol
@@ -833,7 +833,7 @@ linalg_solve <- function(A, B) {
 #' @family linalg
 #' @export
 linalg_lstsq <- function(A, B, rcond = NULL, ..., driver = NULL) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
 
   args <- list(
     self = A,
@@ -1246,6 +1246,6 @@ linalg_inv_ex <- function(A, check_errors = FALSE) {
 #' @family linalg
 #' @export
 linalg_solve_triangular <- function(A, B, ..., upper, left = TRUE, unitriangular = FALSE) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   torch_linalg_solve_triangular(A, B, upper, left, unitriangular)
 }

--- a/R/trace.R
+++ b/R/trace.R
@@ -63,7 +63,7 @@
 #' @export
 jit_trace <- function(func, ..., strict = TRUE) {
   tr_fn <- make_traceable_fn(func)
-  ellipsis::check_dots_unnamed() # we do not support named arguments
+  rlang::check_dots_unnamed() # we do not support named arguments
 
   if (inherits(func, "nn_module")) {
     if (inherits(func, "nn_module_generator")) {


### PR DESCRIPTION
Since ellipsis imports rlang already and ellipsis is superseded. https://rlang.r-lib.org/news/#argument-intake-1-0-0