### PR TITLE
Add a currently unexported `torch_tensor_free` that deletes tensors without requiring us to wait for GC.

### DIFF
--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -417,3 +417,8 @@ torch::Tensor nnf_pad_circular(torch::Tensor input,
 bool cpp_method_Tensor_is_sparse (torch::Tensor x) {
   return lantern_Tensor_is_sparse(x.get());
 }
+
+// [[Rcpp::export]]
+void torch_tensor_free(Rcpp::XPtr<torch::Tensor> x) {
+  x.release();
+}

--- a/src/torch_api.cpp
+++ b/src/torch_api.cpp
@@ -7,7 +7,10 @@
 
 static inline void tensor_finalizer(SEXP ptr) {
   auto xptr = Rcpp::as<Rcpp::XPtr<XPtrTorchTensor>>(ptr);
-  lantern_tensor_set_pyobj(xptr->get(), nullptr);
+  // When the the xptr is released, we might call this function with an invalid ptr.
+  if (xptr.get()) {
+    lantern_tensor_set_pyobj(xptr->get(), nullptr);
+  }
 }
 
 static inline bool rlang_is_named(SEXP x) {
@@ -140,7 +143,9 @@ XPtrTorchTensor from_sexp_tensor(SEXP x) {
   Rcpp::stop("Expected a torch_tensor.");
 }
 
-void delete_tensor(void* x) { lantern_Tensor_delete(x); }
+void delete_tensor(void* x) { 
+  lantern_Tensor_delete(x); 
+}
 
 // optional_torch_tensor
 


### PR DESCRIPTION
@sebffischer Do you want to try out and see if this allows some speedups on your setup?
I didn't see speedups on MPS (memory management on mps is soo different), but maybe it helps with CUDA:

```
library(torch)

p = 100
steps = 1000
n = 1000

device = "mps"

X = torch_randn(n, p, device = device)
beta = torch_randn(p, 1, device = device)
Y = X$matmul(beta)

latent = 5000

net = nn_sequential(
  nn_linear(p, latent),
  nn_relu(),
  nn_linear(latent, 1)
)

net$to(device = device)
opt = optim_adam(net$parameters, lr = 0.01)

t1 = Sys.time()

for (i in 1:steps) {
  opt$zero_grad()
  Y_hat = net(X)
  loss = nnf_mse_loss(Y, Y_hat)
  loss$backward()
  torch:::torch_tensor_free(loss)
  torch:::torch_tensor_free(Y_hat)
}

t2 = Sys.time()

print(paste0("Total time: ", t2 - t1))
```
