### PR TITLE
Provide a way to set gradients to none

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -185,8 +185,8 @@ cpp_set_cuda_allocator_allocator_thresholds <- function(reserved_rate, allocated
     invisible(.Call(`_torch_cpp_set_cuda_allocator_allocator_thresholds`, reserved_rate, allocated_rate, allocated_reserved_rate))
 }
 
-cpp_autograd_zero_grad <- function(x) {
-    invisible(.Call(`_torch_cpp_autograd_zero_grad`, x))
+cpp_autograd_zero_grad <- function(x, set_to_none) {
+    invisible(.Call(`_torch_cpp_autograd_zero_grad`, x, set_to_none))
 }
 
 cpp_backends_mkldnn_is_available <- function() {
@@ -14731,6 +14731,10 @@ nnf_pad_circular <- function(input, padding) {
 
 cpp_method_Tensor_is_sparse <- function(x) {
     .Call(`_torch_cpp_method_Tensor_is_sparse`, x)
+}
+
+torch_tensor_free <- function(x) {
+    invisible(.Call(`_torch_torch_tensor_free`, x))
 }
 
 cpp_torch_tensor_list <- function(x) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -14733,10 +14733,6 @@ cpp_method_Tensor_is_sparse <- function(x) {
     .Call(`_torch_cpp_method_Tensor_is_sparse`, x)
 }
 
-torch_tensor_free <- function(x) {
-    invisible(.Call(`_torch_torch_tensor_free`, x))
-}
-
 cpp_torch_tensor_list <- function(x) {
     .Call(`_torch_cpp_torch_tensor_list`, x)
 }

--- a/R/optim.R
+++ b/R/optim.R
@@ -82,9 +82,9 @@ Optimizer <- R6::R6Class(
       
       self$param_groups <- append(self$param_groups, list(param_group))
     },
-    zero_grad = function() {
+    zero_grad = function(set_to_none = FALSE) {
       for (group in self$param_groups) {
-        cpp_autograd_zero_grad(group$params)
+        cpp_autograd_zero_grad(group$params, set_to_none)
       }
     },
     state_dict = function() {

--- a/inst/include/lantern/lantern.h
+++ b/inst/include/lantern/lantern.h
@@ -2405,10 +2405,10 @@ HOST_API void* lantern_IntArrayRef_get (void* x)
   return ret;
 }
 
-LANTERN_API void (LANTERN_PTR _lantern_autograd_zero_grad) (void * self);
-HOST_API void lantern_autograd_zero_grad (void * self) {
+LANTERN_API void (LANTERN_PTR _lantern_autograd_zero_grad) (void * self, bool set_to_none);
+HOST_API void lantern_autograd_zero_grad (void * self, bool set_to_none) {
   LANTERN_CHECK_LOADED
-  _lantern_autograd_zero_grad(self);
+  _lantern_autograd_zero_grad(self, set_to_none);
   LANTERN_HOST_HANDLER;
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -45345,16 +45345,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// torch_tensor_free
-void torch_tensor_free(Rcpp::XPtr<torch::Tensor> x);
-RcppExport SEXP _torch_torch_tensor_free(SEXP xSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::XPtr<torch::Tensor> >::type x(xSEXP);
-    torch_tensor_free(x);
-    return R_NilValue;
-END_RCPP
-}
 // cpp_torch_tensor_list
 XPtrTorchTensorList cpp_torch_tensor_list(const Rcpp::List& x);
 RcppExport SEXP _torch_cpp_torch_tensor_list(SEXP xSEXP) {
@@ -49295,7 +49285,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_namespace_normal_tensor_tensor", (DL_FUNC) &_torch_cpp_namespace_normal_tensor_tensor, 3},
     {"_torch_nnf_pad_circular", (DL_FUNC) &_torch_nnf_pad_circular, 2},
     {"_torch_cpp_method_Tensor_is_sparse", (DL_FUNC) &_torch_cpp_method_Tensor_is_sparse, 1},
-    {"_torch_torch_tensor_free", (DL_FUNC) &_torch_torch_tensor_free, 1},
     {"_torch_cpp_torch_tensor_list", (DL_FUNC) &_torch_cpp_torch_tensor_list, 1},
     {"_torch_cpp_trace_function", (DL_FUNC) &_torch_cpp_trace_function, 8},
     {"_torch_cpp_save_traced_fn", (DL_FUNC) &_torch_cpp_save_traced_fn, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -518,12 +518,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_autograd_zero_grad
-void cpp_autograd_zero_grad(torch::TensorList x);
-RcppExport SEXP _torch_cpp_autograd_zero_grad(SEXP xSEXP) {
+void cpp_autograd_zero_grad(torch::TensorList x, bool set_to_none);
+RcppExport SEXP _torch_cpp_autograd_zero_grad(SEXP xSEXP, SEXP set_to_noneSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< torch::TensorList >::type x(xSEXP);
-    cpp_autograd_zero_grad(x);
+    Rcpp::traits::input_parameter< bool >::type set_to_none(set_to_noneSEXP);
+    cpp_autograd_zero_grad(x, set_to_none);
     return R_NilValue;
 END_RCPP
 }
@@ -45344,6 +45345,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// torch_tensor_free
+void torch_tensor_free(Rcpp::XPtr<torch::Tensor> x);
+RcppExport SEXP _torch_torch_tensor_free(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<torch::Tensor> >::type x(xSEXP);
+    torch_tensor_free(x);
+    return R_NilValue;
+END_RCPP
+}
 // cpp_torch_tensor_list
 XPtrTorchTensorList cpp_torch_tensor_list(const Rcpp::List& x);
 RcppExport SEXP _torch_cpp_torch_tensor_list(SEXP xSEXP) {
@@ -45647,7 +45658,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_autograd_grad", (DL_FUNC) &_torch_cpp_autograd_grad, 6},
     {"_torch_cpp_set_lantern_allocator", (DL_FUNC) &_torch_cpp_set_lantern_allocator, 1},
     {"_torch_cpp_set_cuda_allocator_allocator_thresholds", (DL_FUNC) &_torch_cpp_set_cuda_allocator_allocator_thresholds, 3},
-    {"_torch_cpp_autograd_zero_grad", (DL_FUNC) &_torch_cpp_autograd_zero_grad, 1},
+    {"_torch_cpp_autograd_zero_grad", (DL_FUNC) &_torch_cpp_autograd_zero_grad, 2},
     {"_torch_cpp_backends_mkldnn_is_available", (DL_FUNC) &_torch_cpp_backends_mkldnn_is_available, 0},
     {"_torch_cpp_backends_mkl_is_available", (DL_FUNC) &_torch_cpp_backends_mkl_is_available, 0},
     {"_torch_cpp_backends_openmp_is_available", (DL_FUNC) &_torch_cpp_backends_openmp_is_available, 0},
@@ -49284,6 +49295,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_namespace_normal_tensor_tensor", (DL_FUNC) &_torch_cpp_namespace_normal_tensor_tensor, 3},
     {"_torch_nnf_pad_circular", (DL_FUNC) &_torch_nnf_pad_circular, 2},
     {"_torch_cpp_method_Tensor_is_sparse", (DL_FUNC) &_torch_cpp_method_Tensor_is_sparse, 1},
+    {"_torch_torch_tensor_free", (DL_FUNC) &_torch_torch_tensor_free, 1},
     {"_torch_cpp_torch_tensor_list", (DL_FUNC) &_torch_cpp_torch_tensor_list, 1},
     {"_torch_cpp_trace_function", (DL_FUNC) &_torch_cpp_trace_function, 8},
     {"_torch_cpp_save_traced_fn", (DL_FUNC) &_torch_cpp_save_traced_fn, 2},

--- a/src/autograd.cpp
+++ b/src/autograd.cpp
@@ -416,6 +416,6 @@ void cpp_set_cuda_allocator_allocator_thresholds (double reserved_rate, double a
 }
 
 // [[Rcpp::export]]
-void cpp_autograd_zero_grad (torch::TensorList x) {
-  lantern_autograd_zero_grad(x.get());
+void cpp_autograd_zero_grad (torch::TensorList x, bool set_to_none) {
+  lantern_autograd_zero_grad(x.get(), set_to_none);
 }

--- a/src/lantern/include/lantern/lantern.h
+++ b/src/lantern/include/lantern/lantern.h
@@ -2405,10 +2405,10 @@ HOST_API void* lantern_IntArrayRef_get (void* x)
   return ret;
 }
 
-LANTERN_API void (LANTERN_PTR _lantern_autograd_zero_grad) (void * self);
-HOST_API void lantern_autograd_zero_grad (void * self) {
+LANTERN_API void (LANTERN_PTR _lantern_autograd_zero_grad) (void * self, bool set_to_none);
+HOST_API void lantern_autograd_zero_grad (void * self, bool set_to_none) {
   LANTERN_CHECK_LOADED
-  _lantern_autograd_zero_grad(self);
+  _lantern_autograd_zero_grad(self, set_to_none);
   LANTERN_HOST_HANDLER;
 }
 

--- a/src/lantern/src/Autograd.cpp
+++ b/src/lantern/src/Autograd.cpp
@@ -299,15 +299,15 @@ void *_lantern_Edge_function(void *self) {
 void _lantern_autograd_zero_grad (void * self, bool set_to_none) {
   LANTERN_FUNCTION_START
   auto list = from_raw::TensorList(self);
-  for (auto &t : list) {
-    auto grad = t.grad();
-    if (grad.defined()) {
-      if (set_to_none) {
-        grad.reset();
-      } else {
-        grad.zero_();
+  for (auto &p : list) {
+    if (p.mutable_grad().defined()) {
+        p.mutable_grad().detach_();
+        if (set_to_none) {
+          p.mutable_grad().reset();
+        } else {
+          p.mutable_grad().zero_();
+        }
       }
-    }
   }
   LANTERN_FUNCTION_END_VOID
 }

--- a/src/lantern/src/Autograd.cpp
+++ b/src/lantern/src/Autograd.cpp
@@ -296,13 +296,17 @@ void *_lantern_Edge_function(void *self) {
   LANTERN_FUNCTION_END
 }
 
-void _lantern_autograd_zero_grad (void * self) {
+void _lantern_autograd_zero_grad (void * self, bool set_to_none) {
   LANTERN_FUNCTION_START
   auto list = from_raw::TensorList(self);
   for (auto &t : list) {
     auto grad = t.grad();
     if (grad.defined()) {
-      grad.zero_();
+      if (set_to_none) {
+        grad.reset();
+      } else {
+        grad.zero_();
+      }
     }
   }
   LANTERN_FUNCTION_END_VOID

--- a/tests/testthat/test-optim-sgd.R
+++ b/tests/testthat/test-optim-sgd.R
@@ -54,3 +54,15 @@ test_that("copy state between optimizers corecctly", {
   
   expect_equal_to_tensor(x, y)
 })
+
+test_that("zero_grad set_to_none", {
+  # start with a tensor and make one step in the optimize
+  x <- torch_tensor(1, requires_grad = TRUE)
+
+  opt <- optim_sgd(x, lr = 0.1)
+  (2*x)$backward()
+  opt$step()
+  opt$zero_grad(set_to_none = TRUE)
+  
+  expect_true(is_undefined_tensor(x$grad))
+})


### PR DESCRIPTION
This allows using `optim$zero_grad(set_to_none=TRUE)` which should reduce memory usage of optimizers. 