### PR TITLE
Try checkout v2 to avoid having to update the OS

### DIFF
--- a/.github/workflows/lantern.yaml
+++ b/.github/workflows/lantern.yaml
@@ -71,7 +71,7 @@ jobs:
           curl -fsSL https://get.docker.com -o get-docker.sh
           DRY_RUN=1 sh ./get-docker.sh
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,7 +76,7 @@ jobs:
           echo "LANTERN_BASE_URL=${{ runner.temp }}/" >> $GITHUB_ENV
         shell: bash
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       
       - uses: ./.github/actions/setup-r
         with:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       
       - uses: ./.github/actions/setup-r
         with:


### PR DESCRIPTION
On CI, things are failing because actions/checkout@v3 requires a recent node version that in turn requires a recent glibc which we don't want to install right now.