### PR TITLE
fix(ignite): making state saveable, param_groups modifieable

### DIFF
--- a/R/ignite.R
+++ b/R/ignite.R
@@ -117,7 +117,8 @@ OptimizerIgnite <- R6::R6Class(
     #' The parameter groups of the optimizer.
     param_groups = function(rhs) {
       if (!missing(rhs)) {
-        prev_param_groups <- self$state_dict()$param_groups
+        prev_param_groups <- self$param_groups
+        all_params = unlist(lapply(prev_param_groups, function(x) x$params))
         if (!is.list(rhs) && length(rhs) == length(prev_param_groups)) {
           value_error("Parameter groups must be a list of the same length as the number of parameter groups.")
         }
@@ -128,8 +129,16 @@ OptimizerIgnite <- R6::R6Class(
             value_error("Parameter groups must have names {paste0(names(prev_param_group), collapse = ', ')} but got {paste0(names(new_param_group), collapse = ', ')}.")
           }
 
-          if (!identical(prev_param_group$params, new_param_group$params)) {
-            value_error("Cannot change the indices of the parameter group, use `$add_param_group()` to add a new parameter group.")
+          param_cmp_value = if (is.integer(new_param_group$params)) {
+            all_params[new_param_group$params]
+          } else {
+            new_param_group$params
+          }
+
+          if (!identical(prev_param_group$params, param_cmp_value)) {
+            print(prev_param_group$params)
+            print(new_param_group$params)
+            value_error("Cannot change the parameter groups, use `$add_param_group()` to add a new parameter group.")
           }
 
           private$.set_param_group_options(self$ptr, rhs)

--- a/tests/testthat/helper-ignite.R
+++ b/tests/testthat/helper-ignite.R
@@ -75,14 +75,12 @@ expect_state_dict_works <- function(optimizer_fn, ...) {
     }
     replicate(2, s())
     if (load) {
-      o$load_state_dict(o$state_dict())
+      o$load_state_dict(torch_load(torch_serialize(o$state_dict())))
     }
     replicate(2, s())
     return(n$parameters)
   }
-  torch_manual_seed(123)
   w1 <- f(load = TRUE)
-  torch_manual_seed(123)
   w2 <- f(load = FALSE)
   expect_equal(w1, w2)
 }


### PR DESCRIPTION
It was impossible to save the state because of:

* https://github.com/mlverse/torch/issues/1233
* undefined tensors were part of the state such as max_exp_avg_sq for adam with amsgrad = FALSE. We now keep them as 0-sized tensors as undefined tensors are not serializeable. (The reason we keep them at all is that it simplifies the saving and loading of state dicts easier)

This PR also improves the tests by removing an unnecessary call to `torch_manual_seed()` that made the tests deterministic