### PR TITLE
ci(dependabot): automatically bump action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
When merging this, PRs will be automatically opened when new versions of the actions are available. I use this in my own packages and it's quite convenient