### PR TITLE
fix(tracing): respect mode in R forward function

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -15345,10 +15345,6 @@ cpp_jit_script_module_add_method <- function(self, method) {
     invisible(.Call(`_torch_cpp_jit_script_module_add_method`, self, method))
 }
 
-cpp_jit_script_module_add_forward <- function(self, list_output) {
-    invisible(.Call(`_torch_cpp_jit_script_module_add_forward`, self, list_output))
-}
-
 cpp_jit_script_module_find_constant <- function(self, name) {
     .Call(`_torch_cpp_jit_script_module_find_constant`, self, name)
 }

--- a/inst/include/lantern/lantern.h
+++ b/inst/include/lantern/lantern.h
@@ -2081,14 +2081,6 @@ HOST_API void lantern_ScriptModule_add_method (void* self, void* method)
   LANTERN_HOST_HANDLER;
 
 }
-LANTERN_API void (LANTERN_PTR _lantern_ScriptModule_add_forward) (void* self, bool list_output);
-HOST_API void lantern_ScriptModule_add_forward (void* self, bool list_output)
-{
-  LANTERN_CHECK_LOADED
-   _lantern_ScriptModule_add_forward(self, list_output);
-  LANTERN_HOST_HANDLER;
-  
-}
 
 LANTERN_API void (LANTERN_PTR _lantern_ScriptModule_save) (void* self, void* path);
 HOST_API void lantern_ScriptModule_save (void* self, void* path)
@@ -10885,7 +10877,6 @@ LOAD_SYMBOL(_lantern_ScriptModule_new);
 LOAD_SYMBOL(_lantern_ScriptModule_add_constant);
 LOAD_SYMBOL(_lantern_ScriptModule_find_constant);
 LOAD_SYMBOL(_lantern_ScriptModule_add_method);
-LOAD_SYMBOL(_lantern_ScriptModule_add_forward);
 LOAD_SYMBOL(_lantern_ScriptModule_save);
 LOAD_SYMBOL(_lantern_ScriptModule_serialize);
 LOAD_SYMBOL(_lantern_ScriptModule_unserialize);

--- a/man/jit_trace.Rd
+++ b/man/jit_trace.Rd
@@ -26,10 +26,13 @@ your problem is a constant structure and does not get used as control flow
 (\code{if}, \code{for}) conditions.}
 
 \item{respect_mode}{(\code{logical(1)})\cr
-Whether the forward method of the resulting module should respect the mode ('train' or 'eval').
-If \code{TRUE} (default), both passes will be jitted and be available as methods \code{trainforward} and \code{evalforward}.
-The \code{forward} method will then select the appropriate method based on the mode of the module.
-If \code{FALSE}, only the current mode of the module will be jitted.}
+Whether both modes ('train' or 'eval') should be traced. If \code{TRUE} (default),
+the underlying C++ ScriptModule will have two methods \code{trainforward()} and
+\code{evalforward()}.
+The \verb{$forward()} method of the R torch module will then select either based
+on the mode.
+If \code{FALSE}, only the current mode of the module will be jitted and hence only
+one \code{forward()} method exists.}
 }
 \value{
 An \code{script_function} if \code{func} is a function and \code{script_module} if
@@ -42,9 +45,6 @@ recording the operations performed on all the tensors.
 }
 \details{
 The resulting recording of a standalone function produces a \code{script_function}.
-}
-\note{
-Scripting is not yet supported in R.
 }
 \section{Warning}{
 
@@ -72,6 +72,7 @@ In cases like these, tracing would not be appropriate and scripting is a better
 choice. If you trace such models, you may silently get incorrect results on
 subsequent invocations of the model. The tracer will try to emit warnings when
 doing something that may cause an incorrect trace to be produced.
+For scripting, see \code{\link{jit_compile}}.
 }
 
 \examples{

--- a/man/jit_trace_module.Rd
+++ b/man/jit_trace_module.Rd
@@ -21,10 +21,13 @@ your problem is a constant structure and does not get used as control flow
 (\code{if}, \code{for}) conditions.}
 
 \item{respect_mode}{(\code{logical(1)})\cr
-Whether the forward method of the resulting module should respect the mode ('train' or 'eval').
-If \code{TRUE} (default), both passes will be jitted and be available as methods \code{trainforward} and \code{evalforward}.
-The \code{forward} method will then select the appropriate method based on the mode of the module.
-If \code{FALSE}, only the current mode of the module will be jitted.}
+Whether both modes ('train' or 'eval') should be traced. If \code{TRUE} (default),
+the underlying C++ ScriptModule will have two methods \code{trainforward()} and
+\code{evalforward()}.
+The \verb{$forward()} method of the R torch module will then select either based
+on the mode.
+If \code{FALSE}, only the current mode of the module will be jitted and hence only
+one \code{forward()} method exists.}
 }
 \description{
 Trace a module and return an executable ScriptModule that will be optimized

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -47471,17 +47471,6 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
-// cpp_jit_script_module_add_forward
-void cpp_jit_script_module_add_forward(XPtrTorchScriptModule self, bool list_output);
-RcppExport SEXP _torch_cpp_jit_script_module_add_forward(SEXP selfSEXP, SEXP list_outputSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrTorchScriptModule >::type self(selfSEXP);
-    Rcpp::traits::input_parameter< bool >::type list_output(list_outputSEXP);
-    cpp_jit_script_module_add_forward(self, list_output);
-    return R_NilValue;
-END_RCPP
-}
 // cpp_jit_script_module_find_constant
 SEXP cpp_jit_script_module_find_constant(XPtrTorchScriptModule self, XPtrTorchstring name);
 RcppExport SEXP _torch_cpp_jit_script_module_find_constant(SEXP selfSEXP, SEXP nameSEXP) {
@@ -51973,7 +51962,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_torch_cpp_jit_script_module_new", (DL_FUNC) &_torch_cpp_jit_script_module_new, 2},
     {"_torch_cpp_jit_script_module_add_constant", (DL_FUNC) &_torch_cpp_jit_script_module_add_constant, 3},
     {"_torch_cpp_jit_script_module_add_method", (DL_FUNC) &_torch_cpp_jit_script_module_add_method, 2},
-    {"_torch_cpp_jit_script_module_add_forward", (DL_FUNC) &_torch_cpp_jit_script_module_add_forward, 2},
     {"_torch_cpp_jit_script_module_find_constant", (DL_FUNC) &_torch_cpp_jit_script_module_find_constant, 2},
     {"_torch_cpp_jit_script_module_save", (DL_FUNC) &_torch_cpp_jit_script_module_save, 2},
     {"_torch_cpp_jit_script_module_serialize", (DL_FUNC) &_torch_cpp_jit_script_module_serialize, 1},

--- a/src/lantern/include/lantern/lantern.h
+++ b/src/lantern/include/lantern/lantern.h
@@ -2081,14 +2081,6 @@ HOST_API void lantern_ScriptModule_add_method (void* self, void* method)
   LANTERN_HOST_HANDLER;
 
 }
-LANTERN_API void (LANTERN_PTR _lantern_ScriptModule_add_forward) (void* self, bool list_output);
-HOST_API void lantern_ScriptModule_add_forward (void* self, bool list_output)
-{
-  LANTERN_CHECK_LOADED
-   _lantern_ScriptModule_add_forward(self, list_output);
-  LANTERN_HOST_HANDLER;
-  
-}
 
 LANTERN_API void (LANTERN_PTR _lantern_ScriptModule_save) (void* self, void* path);
 HOST_API void lantern_ScriptModule_save (void* self, void* path)
@@ -10885,7 +10877,6 @@ LOAD_SYMBOL(_lantern_ScriptModule_new);
 LOAD_SYMBOL(_lantern_ScriptModule_add_constant);
 LOAD_SYMBOL(_lantern_ScriptModule_find_constant);
 LOAD_SYMBOL(_lantern_ScriptModule_add_method);
-LOAD_SYMBOL(_lantern_ScriptModule_add_forward);
 LOAD_SYMBOL(_lantern_ScriptModule_save);
 LOAD_SYMBOL(_lantern_ScriptModule_serialize);
 LOAD_SYMBOL(_lantern_ScriptModule_unserialize);

--- a/src/lantern/src/ScriptModule.cpp
+++ b/src/lantern/src/ScriptModule.cpp
@@ -174,30 +174,6 @@ void _lantern_ScriptModule_add_method(void* self, void* method) {
   LANTERN_FUNCTION_END_VOID
 }
 
-void _lantern_ScriptModule_add_forward(void* self, bool list_output) {
-  LANTERN_FUNCTION_START
-  auto self_ = reinterpret_cast<torch::jit::script::Module*>(self);
-  if (list_output) {
-    self_->define(R"(
-      def forward(self, x) -> List[Tensor]:
-        if self.training:
-          return self.trainforward(x)
-        else:
-          return self.evalforward(x)
-    )");
-  } else {
-    self_->define(R"(
-      def forward(self, x) -> Tensor:
-        if self.training:
-          return self.trainforward(x)
-        else:
-          return self.evalforward(x)
-    )");
-    
-  }
-  LANTERN_FUNCTION_END_VOID
-}
-
 void _lantern_ScriptModule_add_constant(void* self, void* name, void* value) {
   LANTERN_FUNCTION_START
   auto self_ = reinterpret_cast<torch::jit::script::Module*>(self);

--- a/src/script_module.cpp
+++ b/src/script_module.cpp
@@ -120,11 +120,6 @@ void cpp_jit_script_module_add_method(XPtrTorchScriptModule self,
 }
 
 // [[Rcpp::export]]
-void cpp_jit_script_module_add_forward(XPtrTorchScriptModule self, bool list_output) {
-  lantern_ScriptModule_add_forward(self.get(), list_output);
-}
-
-// [[Rcpp::export]]
 SEXP cpp_jit_script_module_find_constant(XPtrTorchScriptModule self,
                                          XPtrTorchstring name) {
   void* ret = lantern_ScriptModule_find_constant(self.get(), name.get());

--- a/tests/testthat/_snaps/script_module.md
+++ b/tests/testthat/_snaps/script_module.md
@@ -1,74 +1,23 @@
 # can print the graph
 
-    graph(%self.1 : __torch__.nn_linear,
-          %x.1 : Tensor):
-      %training : bool = prim::GetAttr[name="training"](%self.1)
-      %19 : Tensor = prim::If(%training) # <string>:3:8
-        block0():
-          %7 : Tensor = prim::CallMethod[name="trainforward"](%self.1, %x.1) # <string>:4:17
-          -> (%7)
-        block1():
-          %10 : Tensor = prim::CallMethod[name="evalforward"](%self.1, %x.1) # <string>:6:17
-          -> (%10)
-      return (%19)
-
----
-
-    graph(%self.1 : __torch__.nn_linear,
-          %x.1 : Tensor):
-      %training : bool = prim::GetAttr[name="training"](%self.1)
-      %19 : Tensor = prim::If(%training) # <string>:3:8
-        block0():
-          %7 : Tensor = prim::CallMethod[name="trainforward"](%self.1, %x.1) # <string>:4:17
-          -> (%7)
-        block1():
-          %10 : Tensor = prim::CallMethod[name="evalforward"](%self.1, %x.1) # <string>:6:17
-          -> (%10)
-      return (%19)
+    graph(%self : __torch__.nn_linear,
+          %4 : Float(10, 10, strides=[10, 1], requires_grad=0, device=cpu)):
+      %bias : Tensor = prim::GetAttr[name="bias"](%self)
+      %weight : Tensor = prim::GetAttr[name="weight"](%self)
+      %5 : Float(10, 10, strides=[10, 1], requires_grad=1, device=cpu) = aten::linear(%4, %weight, %bias)
+      return (%5)
 
 # graph_for
 
-    graph(%self.1 : __torch__.nn_linear1,
-          %x.1 : Tensor):
-      %training : bool = prim::GetAttr[name="training"](%self.1)
-      %3 : Tensor = prim::If(%training) # <string>:3:8
-        block0():
-          %bias.1 : Tensor = prim::GetAttr[name="bias"](%self.1)
-          %weight.1 : Tensor = prim::GetAttr[name="weight"](%self.1)
-          %10 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=0, device=cpu), seen_none=0](%x.1)
-          %11 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=1, device=cpu), seen_none=0](%weight.1)
-          %12 : Tensor = prim::profile[profiled_type=Float(10, strides=[1], requires_grad=1, device=cpu), seen_none=0](%bias.1)
-          %6 : Tensor = aten::linear(%10, %11, %12)
-          %13 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=1, device=cpu), seen_none=0](%6)
-          -> (%13)
-        block1():
-          %bias : Tensor = prim::GetAttr[name="bias"](%self.1)
-          %weight : Tensor = prim::GetAttr[name="weight"](%self.1)
-          %14 : Tensor = prim::profile[profiled_type=Tensor, seen_none=0](%x.1)
-          %15 : Tensor = prim::profile[profiled_type=Tensor, seen_none=0](%weight)
-          %16 : Tensor = prim::profile[profiled_type=Tensor, seen_none=0](%bias)
-          %9 : Tensor = aten::linear(%14, %15, %16)
-          %17 : Tensor = prim::profile[profiled_type=Tensor, seen_none=0](%9)
-          -> (%17)
-      %18 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=1, device=cpu), seen_none=0](%3)
+    graph(%self : __torch__.nn_linear1,
+          %1 : Tensor):
+      %bias : Tensor = prim::GetAttr[name="bias"](%self)
+      %weight : Tensor = prim::GetAttr[name="weight"](%self)
+      %5 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=0, device=cpu), seen_none=0](%1)
+      %6 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=1, device=cpu), seen_none=0](%weight)
+      %7 : Tensor = prim::profile[profiled_type=Float(10, strides=[1], requires_grad=1, device=cpu), seen_none=0](%bias)
+      %4 : Tensor = aten::linear(%5, %6, %7)
+      %8 : Tensor = prim::profile[profiled_type=Float(10, 10, strides=[10, 1], requires_grad=1, device=cpu), seen_none=0](%4)
        = prim::profile()
-      return (%18)
-
----
-
-    graph(%self.1 : __torch__.nn_linear1,
-          %x.1 : Tensor):
-      %training : bool = prim::GetAttr[name="training"](%self.1)
-      %3 : Tensor = prim::If(%training) # <string>:3:8
-        block0():
-          %bias.1 : Tensor = prim::GetAttr[name="bias"](%self.1)
-          %weight.1 : Tensor = prim::GetAttr[name="weight"](%self.1)
-          %42 : Tensor = aten::linear(%x.1, %weight.1, %bias.1)
-          -> (%42)
-        block1():
-          %bias : Tensor = prim::GetAttr[name="bias"](%self.1)
-          %weight : Tensor = prim::GetAttr[name="weight"](%self.1)
-          %47 : Tensor = aten::linear(%x.1, %weight, %bias)
-          -> (%47)
-      return (%3)
+      return (%8)
 

--- a/tests/testthat/test-script_module.R
+++ b/tests/testthat/test-script_module.R
@@ -113,10 +113,6 @@ test_that("can print the graph", {
   traced <- jit_trace(nn_linear(10, 10), torch_randn(10, 10))
 
   expect_snapshot_output({
-    print(traced$forward$graph)
-  })
-
-  expect_snapshot_output({
     print(traced$graph)
   })
 })
@@ -125,10 +121,6 @@ test_that("graph_for", {
   testthat::local_edition(3)
 
   traced <- jit_trace(nn_linear(10, 10), torch_randn(10, 10))
-  expect_snapshot_output({
-    traced$forward$graph_for(torch_randn(10, 10))
-  })
-
   expect_snapshot_output({
     traced$graph_for(torch_randn(10, 10))
   })

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -108,7 +108,7 @@ test_that("can output a list of tensors", {
     list(x, x + 1)
   }
   x <- torch_tensor(1)
-  tr_fn <- jit_trace(fn, x)
+  tr_fn <- jit_trace(fn, x, strict = FALSE)
   expect_equal_to_tensor(fn(x)[[1]], tr_fn(x)[[1]])
   expect_equal_to_tensor(fn(x)[[2]], tr_fn(x)[[2]])
 })
@@ -121,7 +121,7 @@ test_that("fn can take more than 1 argument", {
   x <- torch_tensor(1)
   y <- torch_tensor(2)
 
-  tr_fn <- jit_trace(fn, x, y)
+  tr_fn <- jit_trace(fn, x, y, strict = FALSE)
   expect_equal_to_tensor(fn(x, y)[[1]], tr_fn(x, y)[[1]])
   expect_equal_to_tensor(fn(x, y)[[2]], tr_fn(x, y)[[2]])
 


### PR DESCRIPTION
I realized that because TorchScript is statically typed, we would need to infer the types for the forward method that selects trainforward or evalforward depending on the mode (if we want to register this method in the C++ ScriptModule).
While I still think this is the cleaner approach, I don't immediately now how to do this, so I would defer this to a later point. For now this also works I think.

Resolves Issue #1252