### PR TITLE
fix ubuntu runner obsolescence

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,8 +29,8 @@ jobs:
           # on m1 the R version is whicherver is installed in the runner machine.
           - {os: macOS, r_version: '', version: cpu-m1, runner: [self-hosted, macOS, ARM64]}
 
-          - {os: ubuntu, r_version: release, version: cpu, runner: ubuntu-20.04}
-          - {os: ubuntu, r_version: release, version: cpu, runner: ubuntu-20.04, precxx11abi: 1}
+          - {os: ubuntu, r_version: release, version: cpu, runner: ubuntu-22.04}
+          - {os: ubuntu, r_version: release, version: cpu, runner: ubuntu-22.04, precxx11abi: 1}
           - {os: ubuntu, r_version: release, version: cu12.4, runner: [self-hosted, gpu-local]}
 
           - {os: windows, r_version: release, version: cpu, runner: windows-latest}
@@ -38,7 +38,7 @@ jobs:
         include:
           
           - config: {os: ubuntu, version: cu12.4}
-            container: {image: 'nvidia/cuda:12.4.1-cudnn-devel-ubuntu20.04', options: '--gpus all --runtime=nvidia'}
+            container: {image: 'nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04', options: '--gpus all --runtime=nvidia'}
             cuda_enabled: 1
 
     runs-on: ${{ matrix.config.runner }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
         include:
           
           - config: {os: ubuntu, version: cu12.4}
-            container: {image: 'nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04', options: '--gpus all --runtime=nvidia'}
+            container: {image: 'nvidia/cuda:12.4.1-cudnn-devel-ubuntu20.04', options: '--gpus all --runtime=nvidia'}
             cuda_enabled: 1
 
     runs-on: ${{ matrix.config.runner }}


### PR DESCRIPTION
Ubuntu runner 20.04 are out of support by github action as per Github Action message
><h2 class="text-bold h4">Annotations</h2>
><div class="color-fg-muted text-small">1 error</div>
<a class="d-block no-underline Link--secondary color-fg-default" href="https://github.com/mlverse/torch/actions/runs/15261811294/job/42920892760">
</a>
<div>This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see <a href="https://github.com/actions/runner-images/issues/11101" class="link-gray" rel="noreferrer noopener" data-test-selector="linkified">https://github.com/actions/runner-images/issues/11101</a></div>

---

This P.R. upgrade those to 22.04