### PR TITLE
Possible fix for exploding object size

### DIFF
--- a/R/nn.R
+++ b/R/nn.R
@@ -1,6 +1,16 @@
 #' @include utils-data.R
 NULL
 
+default_parent_env = function() {
+  env = parent.frame(2)
+  pe = parent.env(env)
+  if (all(sapply(c(".__active__", "self", "private", "super"), function(field) exists(field, pe)))) {
+    get("inherit", pe)$parent_env
+  } else {
+    env
+  }
+}
+
 get_inherited_classes <- function(inherit) {
   inherit_class <- inherit$public_fields$.classes
   # Filter out classes that we eventually add in our normal flow.
@@ -496,7 +506,7 @@ is_nn_module <- function(x) {
 #' @export
 nn_module <- function(classname = NULL, inherit = nn_Module, ...,
                       private = NULL, active = NULL,
-                      parent_env = parent.frame()) {
+                      parent_env = default_parent_env()) {
   if (inherits(inherit, "nn_module")) {
     inherit <- attr(inherit, "module")
   }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,11 +2,12 @@ url: https://torch.mlverse.org/docs/
 destination: docs
 template:
   bootstrap: 5
+  math-rendering: mathjax
   bslib:
     primary: "#7e1f77"
   params:
     ganalytics: G-9ZJSKW3L0N
-    
+
 development:
   mode: auto
 
@@ -61,11 +62,11 @@ navbar:
       - text: basic-nn-module
         href: articles/examples/basic-nn-module.html
       - text: dataset
-        href: articles/examples/dataset.html    
-   
-reference:  
+        href: articles/examples/dataset.html
+
+reference:
   - title: Tensor creation utilities
-    contents: 
+    contents:
       - torch_empty
       - torch_arange
       - torch_eye
@@ -135,7 +136,7 @@ reference:
     contents:
       - starts_with("lr_")
   - title: Datasets
-    contents: 
+    contents:
       - starts_with("dataset")
       - iterable_dataset
       - starts_with("dataloader")
@@ -178,7 +179,7 @@ reference:
     contents:
       - starts_with("cuda_")
   - title: JIT
-    contents: 
+    contents:
       - starts_with("jit")
   - title: Backends
     contents:


### PR DESCRIPTION
I am not yet sure whether this has any negative consequences that are problematic.

What do you think about this approach?

If this is a desirable solution to #1320 then I would still need to add more tests.

``` r
devtools::load_all("~/gh/torch")
#> ℹ Loading torch

nn_module1 = nn_module("nn_module1",
  initialize = function(data) {
    self$layer = nn_module("layer",
      initialize = function() {
        self$linear = nn_linear(10, 1)
      },
      forward = function(x) {
        self$linear(x)
      }
    )()
  },
  forward = function(x) {
    self$layer(x)
  }
)

pryr::object_size(nn_module1(rnorm(1L)))
#> 916.75 kB
pryr::object_size(nn_module1(rnorm(1000000L)))
#> 916.75 kB


# What will not work:

nn_module2 = nn_module("nn_module1",
  initialize = function(data) {
    f = nnf_relu
    self$layer = nn_module("layer",
      initialize = function() NULL,
      forward = function(x) {
        f(x)
      }
    )()
  },
  forward = function(x) {
    self$layer(x)
  }
)

nn_module2()(torch_randn(1))
#> Error in f(x): could not find function "f"
```

<sup>Created on 2025-05-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>