### PR TITLE
Change default installation path to R's cache directory.

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -16,6 +16,7 @@ globalVariables(c("..", "self", "private", "N"))
 .onLoad <- function(libname, pkgname) {
   register_s3_method("waldo", "compare_proxy", "torch_tensor")
   register_positron_methods()
+  
   cpp_torch_namespace__store_main_thread_id()
 
   install_success <- TRUE


### PR DESCRIPTION
We used to check if the R's library where the package has been installed is writable and in that case install torch into that library. However, CRAN is no longer allowing us even to check if this directory is writable during checks. 

With this PR we'll default to installing torch to the cache directory. The drawback of this approach is that I don't think this directory is cleaned up when a package is removed. It's shared between R versions too. 

It's thus possible that with time this directory becomes full of LibTorch and LibLantern installations.
Users can clean it up using `torch::torch_cache_dir_purge()`.