### PR TITLE
clarify docs for .iter and .length

### DIFF
--- a/R/utils-data-sampler.R
+++ b/R/utils-data-sampler.R
@@ -24,9 +24,8 @@ Sampler <- R6::R6Class(
 #' 
 #' A sampler must implement the `.iter` and `.length()` methods.
 #' - `initialize` takes in a `data_source`. In general this is a [dataset()].
-#' - `.iter` returns a function that returns a dataset index everytime it's called.
-#' - `.length` returns the maximum number of samples that can be retrieved from
-#'  that sampler.
+#' - `.iter` returns a function that returns an integer vector or coro::exhausted(). For a sampler, the integer vector should have length 1 (the value is one data index). For a batch_sampler, the integer vector should have length equal to batch size (the values are indices in the batch).
+#' - `.length` returns the maximum number of times that .iter() can be called, before it returns coro::exhausted(). For a sampler, this the number of samples. For a batch_sampler, this is the number of batches.
 #' 
 #' @param name (optional) name of the sampler
 #' @param inherit (optional) you can inherit from other samplers to re-use

--- a/man/sampler.Rd
+++ b/man/sampler.Rd
@@ -37,8 +37,7 @@ Samplers can be used with \code{\link[=dataloader]{dataloader()}} when creating 
 A sampler must implement the \code{.iter} and \code{.length()} methods.
 \itemize{
 \item \code{initialize} takes in a \code{data_source}. In general this is a \code{\link[=dataset]{dataset()}}.
-\item \code{.iter} returns a function that returns a dataset index everytime it's called.
-\item \code{.length} returns the maximum number of samples that can be retrieved from
-that sampler.
+\item \code{.iter} returns a function that returns an integer vector or coro::exhausted(). For a sampler, the integer vector should have length 1 (the value is one data index). For a batch_sampler, the integer vector should have length equal to batch size (the values are indices in the batch).
+\item \code{.length} returns the maximum number of times that .iter() can be called, before it returns coro::exhausted(). For a sampler, this the number of samples. For a batch_sampler, this is the number of batches.
 }
 }


### PR DESCRIPTION
Hi @dfalbel 
Would you please consider merging this PR, which clarifies the documentation of .iter and .length methods?

I have an issue https://github.com/mlr-org/mlr3torch/issues/420#issuecomment-3258510397
with the current docs that are unclear for the case of batch_sampler, which needs .length() to return the number of batches, not the number of samples.

Thanks for your consideration!