### PR TITLE
docs: remove duplicate article link in _pkgdown.yml navigation

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -50,8 +50,6 @@ navbar:
         href: articles/memory-management.html
       - text: CUDA compatibility matrix
         href: articles/compatibility-matrix.html
-      - text: Building locally
-        href: articles/modifying-source-code.html
       - text: Automatic Mixed Precision
         href: articles/amp.html
       - text: Modifying source code


### PR DESCRIPTION
## Description
Fixes #1367

## Problem
The pkgdown navigation menu contained two separate links that both referenced the same article, creating redundant navigation entries [attached_file:1].

## Solution
- Removed one duplicate article reference from the navbar configuration
- Keeps navigation clean with single reference per article

## Changes Made
- **Modified:** `_pkgdown.yml` (removed duplicate link entry)

cc @cregouby @al-obrien
