### PR TITLE
Exclude glibc libraries from dependency bundling

### DIFF
--- a/src/lantern/CMakeLists.txt
+++ b/src/lantern/CMakeLists.txt
@@ -230,11 +230,32 @@ option(BUNDLE_DEPENDENCIES "On or off" OFF)
 if (BUNDLE_DEPENDENCIES)
     install(DIRECTORY ${TORCH_PATH} DESTINATION .)
     install(TARGETS lantern RUNTIME_DEPENDENCY_SET lantern_deps)
-    install(RUNTIME_DEPENDENCY_SET lantern_deps 
-		        DESTINATION lib
-		        DIRECTORIES "${TORCH_PATH}/lib/" "${CUDA_TOOLKIT_ROOT_DIR}/bin/"
-		        UNRESOLVED_DEPENDENCIES_VAR unresolved_deps
-		)
+    install(RUNTIME_DEPENDENCY_SET lantern_deps
+        DESTINATION lib
+        DIRECTORIES "${TORCH_PATH}/lib/" "${CUDA_TOOLKIT_ROOT_DIR}/bin/"
+        # Exclude glibc libraries - these must come from the host system.
+        # Bundling glibc causes ABI conflicts because GLIBC_PRIVATE symbols
+        # are unstable across versions. The build environment (Ubuntu 20.04,
+        # glibc 2.31) differs from many target systems (e.g., Ubuntu 24.04,
+        # glibc 2.39), causing "undefined symbol: _dl_catch_error" errors.
+        PRE_EXCLUDE_REGEXES
+            "^libc\\.so"
+            "^libc-"
+            "^libdl\\.so"
+            "^libdl-"
+            "^libpthread\\.so"
+            "^libpthread-"
+            "^librt\\.so"
+            "^librt-"
+            "^libm\\.so"
+            "^libm-"
+            "^ld-linux"
+        POST_EXCLUDE_REGEXES
+            "^/lib/"
+            "^/lib64/"
+            "^/usr/lib/"
+        UNRESOLVED_DEPENDENCIES_VAR unresolved_deps
+    )
 endif()
 
 ############################################################


### PR DESCRIPTION
## Summary

Excludes glibc libraries from the `RUNTIME_DEPENDENCY_SET` to prevent bundling system libraries that cause ABI conflicts on newer Linux distributions.

## Problem

The current build bundles glibc 2.31 components from the Ubuntu 20.04 build environment:
- `libc-2.31.so`, `libdl-2.31.so`, `libpthread-2.31.so`, `librt-2.31.so`, `libm-2.31.so`, `ld-2.31.so`

When loaded on systems with newer glibc (e.g., Ubuntu 24.04 with glibc 2.39), `GLIBC_PRIVATE` symbol mismatches cause runtime failures:

```
liblantern.so - libdl.so.2: undefined symbol: _dl_catch_error, version GLIBC_PRIVATE
```

This manifests inconsistently depending on `LD_LIBRARY_PATH` ordering - if system library paths come first, system glibc wins and it works; otherwise the bundled glibc 2.31 gets loaded via `liblantern.so`'s `RUNPATH=$ORIGIN` and fails.

## Solution

Add `PRE_EXCLUDE_REGEXES` and `POST_EXCLUDE_REGEXES` to the `install(RUNTIME_DEPENDENCY_SET ...)` command to filter out:
- glibc library names (`libc`, `libdl`, `libpthread`, `librt`, `libm`, `ld-linux`)
- System library paths (`/lib/`, `/lib64/`, `/usr/lib/`)

glibc libraries should **never** be bundled on Linux - they must come from the host system. This is standard practice for portable Linux binaries (cf. manylinux approach).

## Test plan

- [ ] Verify lantern builds successfully with `BUNDLE_DEPENDENCIES=ON`
- [ ] Confirm glibc libraries are not present in the resulting package
- [ ] Test on Ubuntu 24.04 (glibc 2.39) with various `LD_LIBRARY_PATH` configurations

## Related issues

- #1323 (Alpine Linux glibc compatibility)
- #663 (ld.so inconsistency)

---
Generated with [Claude Code](https://claude.com/claude-code)