### PR TITLE
Fix sparse CSR tensor bugs: print, to_sparse, as_array

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -15637,6 +15637,10 @@ cpp_method_Tensor_is_sparse <- function(x) {
     .Call(`_torch_cpp_method_Tensor_is_sparse`, x)
 }
 
+cpp_method_Tensor_is_sparse_csr <- function(x) {
+    .Call(`_torch_cpp_method_Tensor_is_sparse_csr`, x)
+}
+
 torch_tensor_free <- function(x) {
     invisible(.Call(`_torch_torch_tensor_free`, x))
 }

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -290,6 +290,9 @@ Tensor <- R7Class(
     is_sparse = function() {
       cpp_method_Tensor_is_sparse(self)
     },
+    is_sparse_csr = function() {
+      cpp_method_Tensor_is_sparse_csr(self)
+    },
     movedim = function(source, destination) {
       private$`_movedim`(as_1_based_dim(source), as_1_based_dim(destination))
     },
@@ -412,7 +415,7 @@ as.matrix.torch_tensor <- function(x, ...) {
 }
 
 as_array_impl <- function(x) {
-  if (x$is_sparse()) {
+  if (x$is_sparse() || x$is_sparse_csr()) {
     cli_abort(c(
       "Sparse tensors are not supported for as_array conversion.",
       i = "Use `as_array(x$to_dense())` to convert to a dense tensor first."

--- a/R/wrapers.R
+++ b/R/wrapers.R
@@ -663,3 +663,21 @@ NULL
 #' @name torch_index_put
 #' @export
 NULL
+
+# Override the generated to_sparse method to work around the optional Layout
+# type mismatch in the C++ layer. The layout-based overload passes a raw
+# torch::Layout* where the Lantern layer expects a self_contained::optional::Layout*,
+# causing a segfault. We route through the sparse_dim overload instead.
+Tensor$set("public", "to_sparse", function(sparse_dim, layout = NULL, blocksize = NULL, dense_dim = NULL) {
+  if (!missing(sparse_dim)) {
+    self$`_to_sparse`(sparse_dim = sparse_dim)
+  } else if (!is.null(layout) || !is.null(blocksize) || !is.null(dense_dim)) {
+    cli::cli_abort(c(
+      "The {.arg layout}, {.arg blocksize}, and {.arg dense_dim} arguments are not yet supported.",
+      i = "Use the dedicated conversion methods instead: {.fn to_sparse_csr}, {.fn to_sparse_csc}, {.fn to_sparse_bsr}, {.fn to_sparse_bsc}."
+    ))
+  } else {
+    # Default: convert to sparse COO format
+    self$`_to_sparse`(sparse_dim = self$dim())
+  }
+})

--- a/R/wrapers.R
+++ b/R/wrapers.R
@@ -671,9 +671,12 @@ NULL
 Tensor$set("public", "to_sparse", function(sparse_dim, layout = NULL, blocksize = NULL, dense_dim = NULL) {
   if (!missing(sparse_dim)) {
     self$`_to_sparse`(sparse_dim = sparse_dim)
-  } else if (!is.null(layout) || !is.null(blocksize) || !is.null(dense_dim)) {
+  } else if (!is.null(dense_dim) && is.null(layout) && is.null(blocksize)) {
+    # For COO format: sparse_dim + dense_dim = ndim
+    self$`_to_sparse`(sparse_dim = self$dim() - dense_dim)
+  } else if (!is.null(layout) || !is.null(blocksize)) {
     cli::cli_abort(c(
-      "The {.arg layout}, {.arg blocksize}, and {.arg dense_dim} arguments are not yet supported.",
+      "The {.arg layout} and {.arg blocksize} arguments are not yet supported.",
       i = "Use the dedicated conversion methods instead: {.fn to_sparse_csr}, {.fn to_sparse_csc}, {.fn to_sparse_bsr}, {.fn to_sparse_bsc}."
     ))
   } else {

--- a/inst/include/lantern/lantern.h
+++ b/inst/include/lantern/lantern.h
@@ -506,6 +506,14 @@ LANTERN_OPTIONAL_DECLS(string_view)
   HOST_API void * lantern_Layout_strided() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_strided(); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse)();
   HOST_API void * lantern_Layout_sparse() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_csr)();
+  HOST_API void * lantern_Layout_sparse_csr() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_csr(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_csc)();
+  HOST_API void * lantern_Layout_sparse_csc() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_csc(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_bsr)();
+  HOST_API void * lantern_Layout_sparse_bsr() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_bsr(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_bsc)();
+  HOST_API void * lantern_Layout_sparse_bsc() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_bsc(); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API const char *(LANTERN_PTR _lantern_Layout_string)(void *x);
   HOST_API const char * lantern_Layout_string(void *x) {LANTERN_CHECK_LOADED const char * ret = _lantern_Layout_string(x); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void *(LANTERN_PTR _lantern_TensorIndex_new)();
@@ -2478,6 +2486,15 @@ HOST_API bool lantern_Tensor_is_sparse (void* x)
 {
   LANTERN_CHECK_LOADED
   bool ret = _lantern_Tensor_is_sparse(x);
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
+LANTERN_API bool (LANTERN_PTR _lantern_Tensor_is_sparse_csr) (void* x);
+HOST_API bool lantern_Tensor_is_sparse_csr (void* x)
+{
+  LANTERN_CHECK_LOADED
+  bool ret = _lantern_Tensor_is_sparse_csr(x);
   LANTERN_HOST_HANDLER;
   return ret;
 }
@@ -10992,6 +11009,7 @@ LOAD_SYMBOL(_lantern_cuda_empty_cache);
 LOAD_SYMBOL(_lantern_cuda_record_memory_history);
 LOAD_SYMBOL(_lantern_cuda_memory_snapshot);
 LOAD_SYMBOL(_lantern_Tensor_is_sparse);
+LOAD_SYMBOL(_lantern_Tensor_is_sparse_csr);
 LOAD_SYMBOL(_lantern_IntArrayRef_get);
 LOAD_SYMBOL(_lantern_autograd_zero_grad);
 LOAD_SYMBOL(_lantern_amp_is_autocast_gpu_enabled);

--- a/src/lantern/include/lantern/lantern.h
+++ b/src/lantern/include/lantern/lantern.h
@@ -506,6 +506,14 @@ LANTERN_OPTIONAL_DECLS(string_view)
   HOST_API void * lantern_Layout_strided() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_strided(); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse)();
   HOST_API void * lantern_Layout_sparse() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_csr)();
+  HOST_API void * lantern_Layout_sparse_csr() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_csr(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_csc)();
+  HOST_API void * lantern_Layout_sparse_csc() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_csc(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_bsr)();
+  HOST_API void * lantern_Layout_sparse_bsr() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_bsr(); LANTERN_HOST_HANDLER return ret;}
+  LANTERN_API void *(LANTERN_PTR _lantern_Layout_sparse_bsc)();
+  HOST_API void * lantern_Layout_sparse_bsc() {LANTERN_CHECK_LOADED void * ret = _lantern_Layout_sparse_bsc(); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API const char *(LANTERN_PTR _lantern_Layout_string)(void *x);
   HOST_API const char * lantern_Layout_string(void *x) {LANTERN_CHECK_LOADED const char * ret = _lantern_Layout_string(x); LANTERN_HOST_HANDLER return ret;}
   LANTERN_API void *(LANTERN_PTR _lantern_TensorIndex_new)();
@@ -2478,6 +2486,15 @@ HOST_API bool lantern_Tensor_is_sparse (void* x)
 {
   LANTERN_CHECK_LOADED
   bool ret = _lantern_Tensor_is_sparse(x);
+  LANTERN_HOST_HANDLER;
+  return ret;
+}
+
+LANTERN_API bool (LANTERN_PTR _lantern_Tensor_is_sparse_csr) (void* x);
+HOST_API bool lantern_Tensor_is_sparse_csr (void* x)
+{
+  LANTERN_CHECK_LOADED
+  bool ret = _lantern_Tensor_is_sparse_csr(x);
   LANTERN_HOST_HANDLER;
   return ret;
 }
@@ -10992,6 +11009,7 @@ LOAD_SYMBOL(_lantern_cuda_empty_cache);
 LOAD_SYMBOL(_lantern_cuda_record_memory_history);
 LOAD_SYMBOL(_lantern_cuda_memory_snapshot);
 LOAD_SYMBOL(_lantern_Tensor_is_sparse);
+LOAD_SYMBOL(_lantern_Tensor_is_sparse_csr);
 LOAD_SYMBOL(_lantern_IntArrayRef_get);
 LOAD_SYMBOL(_lantern_autograd_zero_grad);
 LOAD_SYMBOL(_lantern_amp_is_autocast_gpu_enabled);

--- a/src/lantern/src/Layout.cpp
+++ b/src/lantern/src/Layout.cpp
@@ -18,6 +18,30 @@ void *_lantern_Layout_sparse() {
   LANTERN_FUNCTION_END
 }
 
+void *_lantern_Layout_sparse_csr() {
+  LANTERN_FUNCTION_START
+  return make_raw::Layout(torch::kSparseCsr);
+  LANTERN_FUNCTION_END
+}
+
+void *_lantern_Layout_sparse_csc() {
+  LANTERN_FUNCTION_START
+  return make_raw::Layout(torch::kSparseCsc);
+  LANTERN_FUNCTION_END
+}
+
+void *_lantern_Layout_sparse_bsr() {
+  LANTERN_FUNCTION_START
+  return make_raw::Layout(torch::kSparseBsr);
+  LANTERN_FUNCTION_END
+}
+
+void *_lantern_Layout_sparse_bsc() {
+  LANTERN_FUNCTION_START
+  return make_raw::Layout(torch::kSparseBsc);
+  LANTERN_FUNCTION_END
+}
+
 const char *_lantern_Layout_string(void *x) {
   LANTERN_FUNCTION_START
   std::string str;
@@ -26,6 +50,14 @@ const char *_lantern_Layout_string(void *x) {
     str = "strided";
   } else if (l == torch::kSparse) {
     str = "sparse_coo";
+  } else if (l == torch::kSparseCsr) {
+    str = "sparse_csr";
+  } else if (l == torch::kSparseCsc) {
+    str = "sparse_csc";
+  } else if (l == torch::kSparseBsr) {
+    str = "sparse_bsr";
+  } else if (l == torch::kSparseBsc) {
+    str = "sparse_bsc";
   }
 
   char *cstr = new char[str.length() + 1];

--- a/src/lantern/src/Tensor.cpp
+++ b/src/lantern/src/Tensor.cpp
@@ -49,6 +49,13 @@ const char *_lantern_Tensor_StreamInsertion(void *x) {
     tensor = tensor.dequantize();
   }
 
+  // the stream insertion method calls is_contiguous() which is not
+  // supported for compressed sparse tensors (CSR, CSC, BSR, BSC).
+  // Convert to dense before printing.
+  if (tensor.is_sparse_csr()) {
+    tensor = tensor.to_dense();
+  }
+
   // the stream insertion method seems to cast tensors to float64
   // before printing and that's not supported by the MPS device
   // thus we first cast to CPU, print and later do a regex replace
@@ -412,5 +419,12 @@ bool _lantern_Tensor_is_sparse (void* x) {
   LANTERN_FUNCTION_START
   auto t = from_raw::Tensor(x);
   return t.is_sparse();
+  LANTERN_FUNCTION_END_RET(false)
+}
+
+bool _lantern_Tensor_is_sparse_csr (void* x) {
+  LANTERN_FUNCTION_START
+  auto t = from_raw::Tensor(x);
+  return t.is_sparse_csr();
   LANTERN_FUNCTION_END_RET(false)
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -444,6 +444,11 @@ bool cpp_method_Tensor_is_sparse (torch::Tensor x) {
 }
 
 // [[Rcpp::export]]
+bool cpp_method_Tensor_is_sparse_csr (torch::Tensor x) {
+  return lantern_Tensor_is_sparse_csr(x.get());
+}
+
+// [[Rcpp::export]]
 void torch_tensor_free(Rcpp::XPtr<torch::Tensor> x) {
   x.release();
 }

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -521,6 +521,52 @@ test_that("as_array errors for sparse tensors", {
   )
 })
 
+test_that("CSR sparse tensors can be printed", {
+  x <- torch_randn(3, 3)$to_sparse_csr()
+  expect_output(print(x), "torch_tensor")
+})
+
+test_that("is_sparse_csr works", {
+  x <- torch_randn(3, 3)
+  expect_false(x$is_sparse_csr())
+
+  csr <- x$to_sparse_csr()
+  expect_true(csr$is_sparse_csr())
+
+  coo <- torch_sparse_coo_tensor(
+    torch_tensor(matrix(c(1, 2), nrow = 2), dtype = torch_long()),
+    torch_tensor(1, dtype = torch_float()),
+    size = c(3, 3)
+  )
+  expect_false(coo$is_sparse_csr())
+})
+
+test_that("to_sparse converts CSR back to COO", {
+  x <- torch_eye(3)
+  csr <- x$to_sparse_csr()
+  coo <- csr$to_sparse()
+
+  expect_true(coo$is_sparse())
+  expect_false(coo$is_sparse_csr())
+  expect_equal_to_tensor(coo$to_dense(), x)
+})
+
+test_that("to_sparse with sparse_dim works", {
+  x <- torch_randn(3, 3)
+  sparse <- x$to_sparse(sparse_dim = 2L)
+  expect_true(sparse$is_sparse())
+  expect_equal_to_tensor(sparse$to_dense(), x)
+})
+
+test_that("as_array errors for CSR sparse tensors", {
+  x <- torch_randn(3, 3)$to_sparse_csr()
+  expect_error(
+    as_array(x),
+    "Sparse tensors are not supported for as_array conversion.",
+    fixed = TRUE
+  )
+})
+
 test_that("can make a byte tensor from a raw vector", {
 
   x <- charToRaw("hello world")

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -558,6 +558,19 @@ test_that("to_sparse with sparse_dim works", {
   expect_equal_to_tensor(sparse$to_dense(), x)
 })
 
+test_that("to_sparse with dense_dim works", {
+  x <- torch_randn(3, 4, 5)
+  # dense_dim=1 means the last dim stays dense, sparse_dim = 3 - 1 = 2
+  sparse <- x$to_sparse(dense_dim = 1L)
+  expect_true(sparse$is_sparse())
+  expect_equal_to_tensor(sparse$to_dense(), x)
+
+  # dense_dim=0 is equivalent to full sparse (sparse_dim = ndim)
+  sparse0 <- x$to_sparse(dense_dim = 0L)
+  expect_true(sparse0$is_sparse())
+  expect_equal_to_tensor(sparse0$to_dense(), x)
+})
+
 test_that("as_array errors for CSR sparse tensors", {
   x <- torch_randn(3, 3)$to_sparse_csr()
   expect_error(


### PR DESCRIPTION
## Summary

Fixes #1429 — three bugs with CSR sparse tensor support:

- **Print crash**: Printing a CSR tensor threw "Sparse CSR tensors do not have is_contiguous" because LibTorch's `operator<<` calls `is_contiguous()`. Fixed by converting compressed sparse tensors to dense before printing in `_lantern_Tensor_StreamInsertion`.

- **`$to_sparse()` segfault**: Calling `$to_sparse()` on a CSR tensor crashed R with a segfault due to a type mismatch — the Rcpp layer passes a raw `torch::Layout*` but the Lantern layer interprets it as `self_contained::optional::Layout*`. Added an R-level override that routes through the `sparse_dim` overload, avoiding the broken layout code path. The underlying C++ type mismatch for `from_raw::optional::Layout` should be addressed separately in the headers project.

- **`as_array()` didn't catch CSR tensors**: `is_sparse()` only returns TRUE for COO format. Added `is_sparse_csr()` method (covers CSR, CSC, BSR, BSC) and updated `as_array` to check both sparse formats.

Also adds layout constants and string representations for all compressed sparse formats (CSR, CSC, BSR, BSC).

## Test plan

- [x] CSR sparse tensors print without error
- [x] `is_sparse_csr()` returns correct results for dense, CSR, and COO tensors
- [x] `$to_sparse()` converts CSR back to COO without crashing
- [x] `$to_sparse(sparse_dim = 2L)` works correctly
- [x] `as_array()` gives a helpful error for CSR sparse tensors