### PR TITLE
CRAN release v0.17.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -41,14 +41,14 @@ mnist-r.*
 ^vignettes/using-autograd\.Rmd
 
 # uncomment below for CRAN submission
-# ^inst/bin/.*
-# ^inst/include/(?!torch.h|lantern|torch_RcppExports.h|utils.h|torch_impl.h|torch_types.h|torch_api.h|torch_deleters.h|torch_imports.h).*
-# ^inst/lib/.*
-# ^inst/share/.*
-# ^inst/build-hash
-# ^inst/build-versions
-# ^src/lantern/.*
-# ^tests/testthat/assets/model-v.*
+^inst/bin/.*
+^inst/include/(?!torch.h|lantern|torch_RcppExports.h|utils.h|torch_impl.h|torch_types.h|torch_api.h|torch_deleters.h|torch_imports.h).*
+^inst/lib/.*
+^inst/share/.*
+^inst/build-hash
+^inst/build-versions
+^src/lantern/.*
+^tests/testthat/assets/model-v.*
 
 ^doc$
 ^Meta$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^.github.*
 ^.vscode.*
 ^\.claude$
+^\.superset$
 ^.cache.*
 tools/torchgen/.Rbuildignore
 ^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: torch
 Type: Package
 Title: Tensors and Neural Networks with 'GPU' Acceleration
-Version: 0.16.3.9002
+Version: 0.17.0
 Authors@R: c(
     person("Daniel", "Falbel", email = "daniel@rstudio.com", role = c("aut", "cre", "cph")),
     person("Javier", "Luraschi", email = "jluraschi@gmail.com", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Type: Package
 Title: Tensors and Neural Networks with 'GPU' Acceleration
 Version: 0.17.0
 Authors@R: c(
-    person("Daniel", "Falbel", email = "daniel@rstudio.com", role = c("aut", "cre", "cph")),
+    person("Tomasz", "Kalinowski", role = c("ctb", "cre"), email = "tomasz@posit.co"),
+    person("Daniel", "Falbel", email = "daniel@rstudio.com", role = c("aut", "cph")),
     person("Javier", "Luraschi", email = "jluraschi@gmail.com", role = c("aut")),
     person("Dmitriy", "Selivanov", role = c("ctb")),
     person("Athos", "Damiani", role = c("ctb")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,6 @@ Encoding: UTF-8
 SystemRequirements: LibTorch (https://pytorch.org/); Only x86_64 platforms
   are currently supported except for ARM system running macOS.
 Config/build/copy-method: copy
-Remotes:
-    RcppCore/Rcpp
 LinkingTo:
     Rcpp
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,32 @@
-# torch (development version)
+# torch 0.17.0
 
-- Added `torch_sitrep()` for torch installation situation report. (#1415 cregouby)
-- Added `%*%` method for torch tensors. (#1379)
-- `torch_triu_indices` and `torch_tril_indices` now return 1-based indexes. (#1382)
-- `$indices()` now return 1-based indexes (#1382)
-- Updated to LibTorch 2.8.0 (#1419)
-- Replaced non-API entry point `Rf_findVarInFrame` with `R_getVarEx` for R 4.6 compatibility. (#1421)
+## Breaking changes
+
+- Updated to LibTorch 2.8.0 (#1419).
+- `torch_triu_indices()` and `torch_tril_indices()` now return 1-based indexes (#1382).
+- `$indices()` now returns 1-based indexes (#1382).
+
+## New features
+
+- Added `torch_sitrep()` for torch installation situation report (#1415, @cregouby).
+- Added `%*%` operator for torch tensors (#1379, @caio-hamamura).
+- Added `head()` and `tail()` methods for torch tensors (#1388).
+- Exported `torch_scaled_dot_product_attention()` (#1404).
+- Exported `torch_sparse_sampled_addmm()` (#1427).
+- Exported `torch_ldexp()` (#1407).
+- Integrated `cudatoolkit` R package for CUDA library loading (#1422).
+- Improved `as_array()` support for sparse tensors (#1387).
+
+## Bug fixes
+
+- Fixed sparse CSR tensor printing, `to_sparse()` crash, and `as_array()` detection (#1431).
+- Fixed `dataset()`/`nn_module()` crash when `initialize` parameter is named `d` (#1424, @Chandraveer-Singh).
+- Fixed `bfloat16` not being recognized as a floating point dtype (#1408).
+- Fixed handling of R longjump exceptions in autograd and tracing callbacks (#1406).
+- Fixed redundant `lantern.h` include causing macro redefinition warning (#1430).
+- Excluded glibc libraries from dependency bundling (#1397, @troyhernandez).
+- Replaced non-API entry point `Rf_findVarInFrame` with `R_getVarEx` for R 4.6 compatibility (#1421).
+- Added French translations for 5 missing messages (#1385, @cregouby).
 
 # torch 0.16.3
 

--- a/R/install.R
+++ b/R/install.R
@@ -1,4 +1,4 @@
-branch <- "main"
+branch <- "cran/v0.17.0"
 torch_version <- "2.8.0"
 
 #' Install Torch

--- a/src/indexing.cpp
+++ b/src/indexing.cpp
@@ -45,7 +45,7 @@ std::vector<Rcpp::RObject> enquos0(Rcpp::Environment env) {
 
 void list2env(Rcpp::Environment e, Rcpp::List mask) {
   std::vector<std::string> nms = mask.names();
-  for (auto i = 0; i < nms.size(); i++) {
+  for (size_t i = 0; i < nms.size(); i++) {
     e.assign(nms[i], mask[nms[i]]);
   }
 }
@@ -60,7 +60,7 @@ std::vector<Rcpp::RObject> evaluate_slices(std::vector<Rcpp::RObject> quosures,
   SEXP quosure_e;
   SEXP quosure_c;
   SEXP na = Rcpp::LogicalVector::create(NA_LOGICAL);
-  for (auto i = 0; i < quosures.size(); i++) {
+  for (size_t i = 0; i < quosures.size(); i++) {
     quosure = quosures[i];
     quosure_c = quosure[0];
     quosure_e = quosure[1];
@@ -292,7 +292,7 @@ std::vector<XPtrTorchTensorIndex> slices_to_index(
   SEXP slice;
   int num_dim = 0;
   bool has_ellipsis = false;
-  for (auto i = 0; i < slices.size(); i++) {
+  for (size_t i = 0; i < slices.size(); i++) {
     slice = slices[i];
     auto info = index_append_sexp(index, slice, drop, device);
 
@@ -302,7 +302,7 @@ std::vector<XPtrTorchTensorIndex> slices_to_index(
 
     num_dim += info.dim;
     if (info.vector && !is_put) {
-      bool last_dim = i >= (slices.size() - 1);
+      bool last_dim = i >= slices.size() - 1;
       // we add an ellipsis to get all the other dimensions and append it to the
       // output vector. we only append if it's not the last dimension too.
       if (!last_dim && !has_ellipsis) {

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -30,18 +30,18 @@ void cpp_torch_tensor_print(torch::Tensor x, int n) {
   }
 
   bool truncated = false;
-  if (cont.size() > n && n > 1) {
+  if (static_cast<int>(cont.size()) > n && n > 1) {
     cont.erase(cont.begin() + n, cont.end() - 1);
     truncated = true;
   }
 
   std::string result;
-  for (int i = 0; i < cont.size(); i++) {
+  for (size_t i = 0; i < cont.size(); i++) {
     result += cont.at(i);
 
-    if (i != (cont.size() - 1)) result += "\n";
+    if (i != cont.size() - 1) result += "\n";
 
-    if (i == (cont.size() - 2) && truncated)
+    if (i == cont.size() - 2 && truncated)
       result += "... [the output was truncated (use n=-1 to disable)]\n";
   }
 
@@ -97,7 +97,7 @@ Rcpp::XPtr<XPtrTorchDtype> cpp_torch_tensor_dtype(torch::Tensor x) {
 std::vector<int64_t> stride_from_dim(std::vector<int64_t> x) {
   auto ret = std::vector<int64_t>(x.size());
   ret[0] = 1;
-  for (int i = 1; i < x.size(); i++) {
+  for (size_t i = 1; i < x.size(); i++) {
     ret[i] = ret[i - 1] * x[i - 1];
   }
   return ret;

--- a/src/torch_api.cpp
+++ b/src/torch_api.cpp
@@ -373,9 +373,9 @@ XPtrTorchTensorOptions from_sexp_tensor_options(SEXP x) {
 
     std::vector<std::string> names = args.names();
 
-    for (auto i = 0; i < names.size(); ++i) {
+    for (size_t i = 0; i < names.size(); ++i) {
       auto name = names[i];
-      
+
       if (TYPEOF(args[name]) == NILSXP) {
         continue;
       } else if (name == "dtype") {
@@ -615,7 +615,7 @@ XPtrTorchDimnameList from_sexp_dimname_list(SEXP x) {
   if (TYPEOF(x) == STRSXP) {
     XPtrTorchDimnameList out = lantern_DimnameList();
     auto names = Rcpp::as<std::vector<std::string>>(x);
-    for (int i = 0; i < names.size(); i++) {
+    for (size_t i = 0; i < names.size(); i++) {
       lantern_DimnameList_push_back(out.get(),
                                     XPtrTorchDimname(names[i]).get());
     }
@@ -780,7 +780,7 @@ SEXP operator_sexp_vector_string(const XPtrTorchvector_string* self) {
 XPtrTorchvector_string from_sexp_vector_string(SEXP x) {
   XPtrTorchvector_string out = lantern_vector_string_new();
   auto strings = Rcpp::as<std::vector<std::string>>(x);
-  for (int i = 0; i < strings.size(); i++) {
+  for (size_t i = 0; i < strings.size(); i++) {
     lantern_vector_string_push_back(out.get(), strings.at(i).c_str());
   }
   return out;
@@ -1297,7 +1297,7 @@ SEXP operator_sexp_named_tuple_helper(const XPtrTorchNamedTupleHelper* self) {
   std::vector<std::string> names_ = Rcpp::as<std::vector<std::string>>(names);
   Rcpp::List elements_ = Rcpp::as<Rcpp::List>(elements);
 
-  if (names_.size() != elements_.size()) return elements_;
+  if (names_.size() != static_cast<size_t>(elements_.size())) return elements_;
 
   if (std::all_of(names_.begin(), names_.end(),
                   [](std::string x) { return x.length() != 0; })) {
@@ -1312,7 +1312,7 @@ XPtrTorchNamedTupleHelper from_sexp_named_tuple_helper(SEXP x) {
   auto x_ = Rcpp::as<Rcpp::List>(x);
   auto names = Rcpp::as<std::vector<std::string>>(x_.names());
 
-  for (int i = 0; i < names.size(); i++) {
+  for (size_t i = 0; i < names.size(); i++) {
     lantern_jit_NamedTuple_push_back(out.get(), XPtrTorchstring(names[i]).get(),
                                      Rcpp::as<XPtrTorchIValue>(x_[i]).get());
   }
@@ -1453,7 +1453,7 @@ XPtrTorchIntArrayRef from_sexp_int_array_ref(SEXP x, bool allow_null,
   }
 
   if (index) {
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
       if (vec[i] == 0) {
         Rcpp::stop("Indexing starts at 1 but found a 0.");
       }
@@ -1531,7 +1531,7 @@ XPtrTorchOptionalIntArrayRef from_sexp_optional_int_array_ref(SEXP x,
     }
 
     if (index) {
-      for (int i = 0; i < data.size(); i++) {
+      for (size_t i = 0; i < data.size(); i++) {
         if (data[i] == 0) {
           Rcpp::stop("Indexing starts at 1 but found a 0.");
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -70,22 +70,22 @@ Rcpp::List transpose2(Rcpp::List x) {
   const auto size = x.length();
   std::vector<Rcpp::List> out;
 
-  for (auto i = 0; i < num_elements; i++) {
+  for (R_xlen_t i = 0; i < num_elements; i++) {
     out.push_back(Rcpp::List(size));
   }
 
-  for (size_t j = 0; j < size; j++) {
+  for (R_xlen_t j = 0; j < size; j++) {
     if (Rf_isNull(x[j])) {
       Rcpp::stop("NULL is not allowed. Expected a list.");
     }
     auto el = Rcpp::as<Rcpp::List>(x[j]);
-    for (auto i = 0; i < num_elements; i++) {
+    for (R_xlen_t i = 0; i < num_elements; i++) {
       out[i][j] = el[i];
     }
   }
 
   Rcpp::List ret;
-  for (auto i = 0; i < num_elements; i++) {
+  for (R_xlen_t i = 0; i < num_elements; i++) {
     ret.push_back(out[i]);
   }
 

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -48,7 +48,7 @@ using pre-built binaries. See (#pre-built) for more information.
 
 Since version 0.1.1 torch supports GPU installation on Windows. In order to use GPU's with torch you need to:
 
--   Have a CUDA compatible NVIDIA GPU. You can find if you have a CUDA compatible GPU [here](https://developer.nvidia.com/cuda-gpus#compute).
+-   Have a CUDA compatible NVIDIA GPU. You can find if you have a CUDA compatible GPU [here](https://developer.nvidia.com/cuda/gpus#compute).
 
 -   Have properly installed the NVIDIA CUDA toolkit version 12.8. For CUDA v12.8, follow the installation instructions [here](https://developer.nvidia.com/cuda-12-8-1-download-archive). **Note**: The version of the CUDA toolkit must match exactly what's mentioed above.
 
@@ -60,7 +60,7 @@ Once you have installed all pre-requisites you can install `torch` with:
 install.packages("torch")
 ```
 
-If you have followed default installation locations we will detect that you have CUDA software installed and automatically download the GPU enabled Lantern binaries. You can also specify the `CUDA` env var with something like `Sys.setenv(CUDA="12.8")` if you want to force an specific version of the CUDA toolkit. Refer to the [compatibility matrix](./compatibility-matrix) to select your version.
+If you have followed default installation locations we will detect that you have CUDA software installed and automatically download the GPU enabled Lantern binaries. You can also specify the `CUDA` env var with something like `Sys.setenv(CUDA="12.8")` if you want to force an specific version of the CUDA toolkit. Refer to the [compatibility matrix](https://torch.mlverse.org/docs/dev/articles/compatibility-matrix.html) to select your version.
 
 ## MacOS
 
@@ -97,7 +97,7 @@ using pre-built binaries. See (#pre-built) for more information.
 
 To install the GPU version of `torch` on linux you must verify that:
 
--   You have a NVIDIA CUDA compatible GPU. You can find if you have a CUDA compatible GPU [here](https://developer.nvidia.com/cuda-gpus#compute).
+-   You have a NVIDIA CUDA compatible GPU. You can find if you have a CUDA compatible GPU [here](https://developer.nvidia.com/cuda/gpus#compute).
 
 -   You have correctly installed the NVIDIA CUDA Toolkit versions 12.6, 12.8, or 12.9, follow the instructions [here](https://docs.nvidia.com/cuda/).
 
@@ -109,7 +109,7 @@ Once you have installed all pre-requisites you can install `torch` with:
 install.packages("torch")
 ```
 
-If you have followed default installation locations we will detect that you have CUDA software installed and automatically download the GPU enabled Lantern binaries. You can also specify the `CUDA` env var with something like `Sys.setenv(CUDA="12.8")` if you want to force an specific version of the CUDA toolkit. Refer to the [compatibility matrix](./compatibility-matrix) to select your version.
+If you have followed default installation locations we will detect that you have CUDA software installed and automatically download the GPU enabled Lantern binaries. You can also specify the `CUDA` env var with something like `Sys.setenv(CUDA="12.8")` if you want to force an specific version of the CUDA toolkit. Refer to the [compatibility matrix](https://torch.mlverse.org/docs/dev/articles/compatibility-matrix.html) to select your version.
 
 ## Installing from pre-built binaries {#pre-built}
 


### PR DESCRIPTION
## Summary
- Prepare torch for CRAN release v0.17.0
- Updated to LibTorch 2.8.0
- Bumped version to 0.17.0, set branch for lantern binary downloads
- Uncommented CRAN submission lines in .Rbuildignore
- Polished NEWS.md entries

## Changes in this release
- **Breaking**: LibTorch 2.8.0 update, 1-based indexing for `torch_triu_indices()`, `torch_tril_indices()`, and `$indices()`
- **New features**: `torch_sitrep()`, `%*%` operator, `head()`/`tail()` for tensors, exported `torch_scaled_dot_product_attention()`, `torch_sparse_sampled_addmm()`, `torch_ldexp()`, cudatoolkit integration, improved sparse tensor support
- **Bug fixes**: sparse CSR tensors, `bfloat16` dtype, R longjump exceptions, R 4.6 compatibility, and more