### PR TITLE
Fix CRAN check: replace non-API R_UnboundValue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,8 @@ Encoding: UTF-8
 SystemRequirements: LibTorch (https://pytorch.org/); Only x86_64 platforms
   are currently supported except for ARM system running macOS.
 Config/build/copy-method: copy
+Remotes:
+    RcppCore/Rcpp
 LinkingTo:
     Rcpp
 Imports:

--- a/src/indexing.cpp
+++ b/src/indexing.cpp
@@ -4,11 +4,8 @@
 #define TORCH_PRENV(x) TAG(x)
 
 static R_len_t dots_size(SEXP dots) {
-  if (dots == R_UnboundValue) {
-    // No dots at all in the environment
-    return 0;
-  } else if (dots == R_MissingArg) {
-    // Dots are present, but none were supplied
+  if (dots == R_MissingArg) {
+    // No dots at all, or dots are present but none were supplied
     return 0;
   } else {
     return Rf_length(dots);
@@ -18,9 +15,10 @@ static R_len_t dots_size(SEXP dots) {
 // [[Rcpp::export]]
 std::vector<Rcpp::RObject> enquos0(Rcpp::Environment env) {
 #if R_VERSION >= R_Version(4, 5, 0)
-  SEXP dots = R_getVarEx(R_DotsSymbol, env, FALSE, R_UnboundValue);
+  SEXP dots = R_getVarEx(R_DotsSymbol, env, FALSE, R_MissingArg);
 #else
   SEXP dots = Rf_findVarInFrame(env, R_DotsSymbol);
+  if (dots == R_UnboundValue) dots = R_MissingArg;
 #endif
   std::vector<Rcpp::RObject> out;
   R_len_t size = dots_size(dots);

--- a/src/indexing.cpp
+++ b/src/indexing.cpp
@@ -4,21 +4,18 @@
 #define TORCH_PRENV(x) TAG(x)
 
 static R_len_t dots_size(SEXP dots) {
-  if (dots == R_MissingArg) {
-    // No dots at all, or dots are present but none were supplied
-    return 0;
-  } else {
+  if (TYPEOF(dots) == DOTSXP) {
     return Rf_length(dots);
   }
+  return 0;
 }
 
 // [[Rcpp::export]]
 std::vector<Rcpp::RObject> enquos0(Rcpp::Environment env) {
 #if R_VERSION >= R_Version(4, 5, 0)
-  SEXP dots = R_getVarEx(R_DotsSymbol, env, FALSE, R_MissingArg);
+  SEXP dots = R_getVarEx(R_DotsSymbol, env, FALSE, R_NilValue);
 #else
   SEXP dots = Rf_findVarInFrame(env, R_DotsSymbol);
-  if (dots == R_UnboundValue) dots = R_MissingArg;
 #endif
   std::vector<Rcpp::RObject> out;
   R_len_t size = dots_size(dots);


### PR DESCRIPTION
## Summary

- Removes references to `R_UnboundValue` (a non-API R symbol) from code compiled on R >= 4.5.0
- Uses `R_MissingArg` as the sentinel value for `R_getVarEx()` instead
- On R < 4.5.0, converts `R_UnboundValue` from `Rf_findVarInFrame()` to `R_MissingArg` immediately, so `dots_size()` only checks `R_MissingArg`

Fixes CRAN notes:
```
Found non-API call to R: 'R_UnboundValue'
Compiled code should not call non-API entry points in R.
```

## Test plan
- [ ] `R CMD check` passes without the non-API note
- [ ] Tensor indexing (`x[1, ]`, `x[, 1]`, `x[]`, etc.) still works correctly