### PR TITLE
Split GPU testing into Docker-based build/test workflow

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -17,7 +17,11 @@ RUN curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg 
     && apt-get update \
     && apt-get install -y r-rig \
     && rig add release \
+    && rig default release \
     && rm -rf /var/lib/apt/lists/*
+
+# Verify R is on PATH and show library paths
+RUN which R && R --version | head -1 && Rscript -e "cat(.libPaths(), sep='\n')"
 
 # Parallel compilation
 RUN echo "MAKEFLAGS=-j$(nproc)" >> "$(R RHOME)/etc/Renviron.site"
@@ -39,8 +43,9 @@ RUN Rscript -e "\
     pak::pkg_install('mlverse/cudatoolkit/cuda12.8')" \
     && rm -rf /tmp/* /root/.cache
 
-# Install torch with tests
-RUN R CMD INSTALL --install-tests /build
+# Install torch with tests (use same library as pak)
+RUN Rscript -e "lib <- .libPaths()[1]; cat('Installing to:', lib, '\n')" \
+    && R CMD INSTALL --install-tests --library=$(Rscript -e "cat(.libPaths()[1])") /build
 
 # Trigger LibTorch download and clean up temp files
 RUN Rscript -e "library(torch)" \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies
+RUN apt-get update -y && apt-get install -y \
+    sudo software-properties-common dialog apt-utils \
+    tzdata locales curl wget git \
+    libcurl4-openssl-dev libssl-dev libxml2-dev \
+    libfontconfig1-dev libfreetype6-dev libpng-dev \
+    libharfbuzz-dev libfribidi-dev libtiff5-dev libjpeg-dev \
+    cmake make gcc g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install R via rig
+RUN curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux-latest.tar.gz | \
+    tar xz -C /usr/local && \
+    rig add release && \
+    ln -sf /opt/R/$(ls /opt/R)/bin/R /usr/local/bin/R && \
+    ln -sf /opt/R/$(ls /opt/R)/bin/Rscript /usr/local/bin/Rscript
+
+# Parallel compilation
+RUN echo "MAKEFLAGS=-j$(nproc)" >> "$(R RHOME)/etc/Renviron.site"
+
+# Copy source and optional lantern artifacts
+COPY . /build
+
+ARG LANTERN_BASE_URL=""
+ENV LANTERN_BASE_URL=${LANTERN_BASE_URL}
+
+ARG TORCH_URL=""
+ENV TORCH_URL=${TORCH_URL}
+ENV TORCH_INSTALL=1
+
+# Install pak, R dependencies, and cudatoolkit
+RUN Rscript -e "\
+    install.packages('pak', repos = 'https://r-lib.github.io/p/pak/devel/'); \
+    pak::local_install_deps('/build'); \
+    pak::pkg_install('mlverse/cudatoolkit/cuda12.8')"
+
+# Install torch with tests
+RUN R CMD INSTALL --install-tests /build
+
+# Trigger LibTorch download
+RUN Rscript -e "library(torch)"
+
+ENV TORCH_TEST=1

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -41,7 +41,7 @@ ENV TORCH_INSTALL=1
 # Install pak, R dependencies, and cudatoolkit
 RUN Rscript -e "\
     install.packages('pak', repos = 'https://r-lib.github.io/p/pak/devel/'); \
-    pak::local_install_deps('/build'); \
+    pak::local_install_deps('/build', dependencies = TRUE); \
     pak::pkg_install('mlverse/cudatoolkit/cuda12.8')" \
     && rm -rf /tmp/* /root/.cache
 

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -9,15 +9,15 @@ RUN apt-get update -y && apt-get install -y \
     libcurl4-openssl-dev libssl-dev libxml2-dev \
     libfontconfig1-dev libfreetype6-dev libpng-dev \
     libharfbuzz-dev libfribidi-dev libtiff5-dev libjpeg-dev \
-    cmake make gcc g++ \
-    && rm -rf /var/lib/apt/lists/*
+    cmake make gcc g++
 
 # Install R via rig
-RUN curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux-latest.tar.gz | \
-    tar xz -C /usr/local && \
-    rig add release && \
-    ln -sf /opt/R/$(ls /opt/R)/bin/R /usr/local/bin/R && \
-    ln -sf /opt/R/$(ls /opt/R)/bin/Rscript /usr/local/bin/Rscript
+RUN curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg \
+    && echo "deb http://rig.r-pkg.org/deb rig main" > /etc/apt/sources.list.d/rig.list \
+    && apt-get update \
+    && apt-get install -y r-rig \
+    && rig add release \
+    && rm -rf /var/lib/apt/lists/*
 
 # Parallel compilation
 RUN echo "MAKEFLAGS=-j$(nproc)" >> "$(R RHOME)/etc/Renviron.site"

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -20,8 +20,10 @@ RUN curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg 
     && rig default release \
     && rm -rf /var/lib/apt/lists/*
 
-# Verify R is on PATH and show library paths
-RUN which R && R --version | head -1 && Rscript -e "cat(.libPaths(), sep='\n')"
+# Use a fixed library path (not HOME-dependent) so packages are found
+# regardless of what HOME is set to at runtime (GitHub Actions sets HOME=/github/home)
+ENV R_LIBS_USER=/opt/R/library
+RUN mkdir -p /opt/R/library
 
 # Parallel compilation
 RUN echo "MAKEFLAGS=-j$(nproc)" >> "$(R RHOME)/etc/Renviron.site"
@@ -43,9 +45,8 @@ RUN Rscript -e "\
     pak::pkg_install('mlverse/cudatoolkit/cuda12.8')" \
     && rm -rf /tmp/* /root/.cache
 
-# Install torch with tests (use same library as pak)
-RUN Rscript -e "lib <- .libPaths()[1]; cat('Installing to:', lib, '\n')" \
-    && R CMD INSTALL --install-tests --library=$(Rscript -e "cat(.libPaths()[1])") /build
+# Install torch with tests
+RUN R CMD INSTALL --install-tests /build
 
 # Trigger LibTorch download and clean up temp files
 RUN Rscript -e "library(torch)" \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -36,12 +36,14 @@ ENV TORCH_INSTALL=1
 RUN Rscript -e "\
     install.packages('pak', repos = 'https://r-lib.github.io/p/pak/devel/'); \
     pak::local_install_deps('/build'); \
-    pak::pkg_install('mlverse/cudatoolkit/cuda12.8')"
+    pak::pkg_install('mlverse/cudatoolkit/cuda12.8')" \
+    && rm -rf /tmp/* /root/.cache
 
 # Install torch with tests
 RUN R CMD INSTALL --install-tests /build
 
-# Trigger LibTorch download
-RUN Rscript -e "library(torch)"
+# Trigger LibTorch download and clean up temp files
+RUN Rscript -e "library(torch)" \
+    && rm -rf /tmp/* /build
 
 ENV TORCH_TEST=1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -135,8 +135,8 @@ jobs:
           build-args: |
             TORCH_URL=${{ env.TORCH_URL }}
             LANTERN_BASE_URL=${{ needs.lantern.result == 'success' && '/build/lantern/' || '' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-ci:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}-ci:cache,mode=max
 
   test-gpu:
     needs: build-gpu-image

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Run tests
         run: |
-          Rscript -e "testthat::test_package('torch')"
+          Rscript -e "testthat::test_package('torch', reporter = 'progress')"
 
   test-cudatoolkit:
     needs: build-gpu-image
@@ -196,4 +196,4 @@ jobs:
 
       - name: Run tests
         run: |
-          Rscript -e "testthat::test_package('torch')"
+          Rscript -e "testthat::test_package('torch', reporter = 'progress')"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -138,6 +138,7 @@ jobs:
 
   test-gpu:
     needs: build-gpu-image
+    if: ${{ needs.build-gpu-image.result == 'success' }}
     runs-on: [self-hosted, gpu-local]
     container:
       image: ${{ needs.build-gpu-image.outputs.image }}
@@ -168,6 +169,7 @@ jobs:
 
   test-cudatoolkit:
     needs: build-gpu-image
+    if: ${{ needs.build-gpu-image.result == 'success' }}
     runs-on: [self-hosted, gpu-local]
     container:
       image: ${{ needs.build-gpu-image.outputs.image }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,15 +33,7 @@ jobs:
           - {os: ubuntu, r_version: devel, version: cpu, runner: ubuntu-22.04}
           - {os: windows, r_version: release, version: cpu, runner: windows-latest}
 
-        include:
-
-          - config: {os: ubuntu, r_version: release, version: cu12.8, runner: [self-hosted, gpu-local]}
-            container: {image: 'nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04', options: '--gpus all --runtime=nvidia'}
-            cuda_enabled: 1
-            torch_url: 'https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorch-for-R/libtorch-linux-cuda128-Release-x86_64-v2.8.0.zip'
-
     runs-on: ${{ matrix.config.runner }}
-    container: ${{ matrix.container }}
     
     name: "${{ matrix.config.os }} R: ${{ matrix.config.r_version }} - ${{matrix.config.version}}"
     timeout-minutes: 120
@@ -49,8 +41,6 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       TORCH_TEST: 1
       TORCH_INSTALL: 1
-      TORCH_TEST_CUDA: ${{ matrix.cuda_enabled }}
-      TORCH_URL: ${{ matrix.torch_url }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       GHA_USE_NODE_20: false
@@ -72,21 +62,6 @@ jobs:
         shell: bash
 
       - uses: actions/checkout@v6
-
-      - if: ${{ env.TORCH_TEST_CUDA == 1 }}
-        shell: bash
-        run: |
-          nvidia-smi
-          echo "--- LD_LIBRARY_PATH ---"
-          echo "${LD_LIBRARY_PATH:-<not set>}"
-          echo "--- CUDA libs ---"
-          ls /usr/local/cuda/lib64/libcudart* /usr/local/cuda/lib64/libcublas* 2>/dev/null || echo "not found in /usr/local/cuda/lib64"
-          ldconfig -p | grep -E "libcudart|libcublas" || echo "not in ldconfig cache"
-
-      - name: Set LD_LIBRARY_PATH for CUDA
-        if: ${{ env.TORCH_TEST_CUDA == 1 }}
-        run: echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> $GITHUB_ENV
-        shell: bash
 
       - uses: ./.github/actions/setup-r
         with:
@@ -113,73 +88,105 @@ jobs:
           error-on: '"error"'
           args: 'c("--no-multiarch", "--no-manual", "--as-cran")'
 
-  check-cudatoolkit:
+  build-gpu-image:
     needs: lantern
     if: ${{ always() && needs.lantern.result != 'failed' }}
-    runs-on: [self-hosted, gpu-local]
-    container:
-      image: nvidia/cuda:12.8.1-base-ubuntu22.04
-      options: '--gpus all --runtime=nvidia'
-    name: "cudatoolkit - cuda12.8"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 120
+    outputs:
+      image: ghcr.io/${{ github.repository }}-ci:${{ github.sha }}
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      TORCH_TEST: 1
-      TORCH_INSTALL: 1
-      TORCH_TEST_CUDA: 1
-      CUDA: "12.8"
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      DEBIAN_FRONTEND: noninteractive
-      R_ALWAYS_INSTALL_TESTS: true
       TORCH_URL: 'https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorch-for-R/libtorch-linux-cuda128-Release-x86_64-v2.8.0.zip'
 
     steps:
+      - uses: actions/checkout@v6
 
-      - name: Install system dependencies
-        run: |
-          apt-get update -y
-          apt-get install -y \
-            sudo software-properties-common dialog apt-utils \
-            tzdata locales curl wget git \
-            libcurl4-openssl-dev libssl-dev libxml2-dev \
-            libfontconfig1-dev libfreetype6-dev libpng-dev \
-            libharfbuzz-dev libfribidi-dev libtiff5-dev libjpeg-dev \
-            cmake make gcc g++
+      - name: Create lantern directory
+        run: mkdir -p lantern
 
+      - name: Download lantern artifacts
+        if: ${{ needs.lantern.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          pattern: lantern-*
+          path: 'lantern/'
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}-ci:${{ github.sha }}
+          build-args: |
+            TORCH_URL=${{ env.TORCH_URL }}
+            LANTERN_BASE_URL=${{ needs.lantern.result == 'success' && '/build/lantern/' || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  test-gpu:
+    needs: build-gpu-image
+    runs-on: [self-hosted, gpu-local]
+    container:
+      image: ${{ needs.build-gpu-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: '--gpus all --runtime=nvidia'
+    name: "GPU tests - cuda12.8"
+    timeout-minutes: 60
+    env:
+      TORCH_TEST: 1
+      TORCH_TEST_CUDA: 1
+      TORCH_CUDATOOLKIT: 'FALSE'
+      LD_LIBRARY_PATH: /usr/local/cuda/lib64
+
+    steps:
       - name: Verify GPU access
         run: nvidia-smi
 
-      - name: Download lantern artifacts
-        if: ${{ needs.lantern.result != 'skipped' }}
-        uses: actions/download-artifact@v7
-        with:
-          pattern: lantern-*
-          path: '${{ runner.temp }}/'
-          merge-multiple: true
-
-      - name: Set base URL for downloading
-        if: ${{ needs.lantern.result != 'skipped' }}
+      - name: Session info
         run: |
-          echo "LANTERN_BASE_URL=${{ runner.temp }}/" >> $GITHUB_ENV
-        shell: bash
+          Rscript -e "sessionInfo()"
+          Rscript -e "library(torch); cat('torch loaded, CUDA available:', cuda_is_available(), '\n')"
 
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-r
-        with:
-          r_version: release
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          cache: false
-
-      - name: Install cuda12.8 R package
+      - name: Run tests
         run: |
-          Rscript -e "pak::pkg_install('mlverse/cudatoolkit/cuda12.8')"
+          Rscript -e "testthat::test_package('torch')"
 
-      - name: Install package
-        run: |
-          Rscript -e "pak::local_install()"
+  test-cudatoolkit:
+    needs: build-gpu-image
+    runs-on: [self-hosted, gpu-local]
+    container:
+      image: ${{ needs.build-gpu-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: '--gpus all --runtime=nvidia'
+    name: "cudatoolkit - cuda12.8"
+    timeout-minutes: 60
+    env:
+      TORCH_TEST: 1
+      TORCH_TEST_CUDA: 1
+      CUDA: "12.8"
+
+    steps:
+      - name: Verify GPU access
+        run: nvidia-smi
 
       - name: Session info
         run: |
@@ -190,4 +197,3 @@ jobs:
       - name: Run tests
         run: |
           Rscript -e "testthat::test_package('torch')"
-

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -135,8 +135,6 @@ jobs:
           build-args: |
             TORCH_URL=${{ env.TORCH_URL }}
             LANTERN_BASE_URL=${{ needs.lantern.result == 'success' && '/build/lantern/' || '' }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-ci:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}-ci:cache,mode=max
 
   test-gpu:
     needs: build-gpu-image

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -138,7 +138,7 @@ jobs:
 
   test-gpu:
     needs: build-gpu-image
-    if: ${{ needs.build-gpu-image.result == 'success' }}
+    if: ${{ always() && needs.build-gpu-image.result == 'success' }}
     runs-on: [self-hosted, gpu-local]
     container:
       image: ${{ needs.build-gpu-image.outputs.image }}
@@ -169,7 +169,7 @@ jobs:
 
   test-cudatoolkit:
     needs: build-gpu-image
-    if: ${{ needs.build-gpu-image.result == 'success' }}
+    if: ${{ always() && needs.build-gpu-image.result == 'success' }}
     runs-on: [self-hosted, gpu-local]
     container:
       image: ${{ needs.build-gpu-image.outputs.image }}


### PR DESCRIPTION
## Summary

- Moves GPU test infrastructure from running everything on self-hosted GPU runners to a two-stage Docker-based approach
- **Build stage** (`build-gpu-image`): On a cheap GitHub-hosted runner, builds a Docker image with R (via rig), all dependencies, torch (with tests), LibTorch, and cudatoolkit pre-installed. Pushes to ghcr.io.
- **Test stage** (`test-gpu`, `test-cudatoolkit`): On the GPU runner, pulls the pre-built image and only runs `testthat::test_package('torch')` — no compilation, no dependency installation
- Removes the GPU matrix entry and `check-cudatoolkit` job from the existing `check` workflow
- The `check` job for macOS, Windows, and Linux CPU is unchanged

This should significantly reduce GPU runner wall time since the expensive build/install work now happens on GitHub-hosted runners.

## Test plan

- [ ] `build-gpu-image` job succeeds and pushes image to ghcr.io
- [ ] `test-gpu` job pulls image, detects GPU, and runs tests with system CUDA
- [ ] `test-cudatoolkit` job pulls image and runs tests via cudatoolkit R package
- [ ] Existing `check` matrix (macOS Intel, macOS M1, Ubuntu CPU, Windows) is unaffected