### PR TITLE
Add move semantics and reduce shared_ptr copy overhead

### DIFF
--- a/inst/include/torch_types.h
+++ b/inst/include/torch_types.h
@@ -27,6 +27,9 @@ class XPtrTorchIndexTensor : public XPtrTorch {
   explicit XPtrTorchIndexTensor(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchIndexTensor(const XPtrTorchIndexTensor& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchIndexTensor(XPtrTorchIndexTensor&&) = default;
+  XPtrTorchIndexTensor& operator=(const XPtrTorchIndexTensor&) = default;
+  XPtrTorchIndexTensor& operator=(XPtrTorchIndexTensor&&) = default;
   explicit XPtrTorchIndexTensor(SEXP x);
   operator SEXP() const;
 };
@@ -39,6 +42,9 @@ class XPtrTorchTensor : public XPtrTorch {
   XPtrTorchTensor(void* x) : XPtrTorch(x, delete_tensor) {}
   explicit XPtrTorchTensor(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchTensor(const XPtrTorchTensor& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchTensor(XPtrTorchTensor&&) = default;
+  XPtrTorchTensor& operator=(const XPtrTorchTensor&) = default;
+  XPtrTorchTensor& operator=(XPtrTorchTensor&&) = default;
   XPtrTorchTensor(XPtrTorchIndexTensor x) : XPtrTorch(x.get_shared()) {}
   explicit XPtrTorchTensor(SEXP x);
   operator SEXP() const;
@@ -50,6 +56,9 @@ class XPtrTorchScriptModule : public XPtrTorch {
   explicit XPtrTorchScriptModule(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchScriptModule(const XPtrTorchScriptModule& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchScriptModule(XPtrTorchScriptModule&&) = default;
+  XPtrTorchScriptModule& operator=(const XPtrTorchScriptModule&) = default;
+  XPtrTorchScriptModule& operator=(XPtrTorchScriptModule&&) = default;
   explicit XPtrTorchScriptModule(SEXP x);
   operator SEXP() const;
 };
@@ -62,6 +71,9 @@ class XPtrTorchScriptMethod : public XPtrTorch {
   explicit XPtrTorchScriptMethod(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchScriptMethod(const XPtrTorchScriptMethod& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchScriptMethod(XPtrTorchScriptMethod&&) = default;
+  XPtrTorchScriptMethod& operator=(const XPtrTorchScriptMethod&) = default;
+  XPtrTorchScriptMethod& operator=(XPtrTorchScriptMethod&&) = default;
   explicit XPtrTorchScriptMethod(SEXP x);
   operator SEXP() const;
 };
@@ -72,6 +84,9 @@ class XPtrTorchOptionalTensor : public XPtrTorch {
   explicit XPtrTorchOptionalTensor(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchOptionalTensor(const XPtrTorchOptionalTensor& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchOptionalTensor(XPtrTorchOptionalTensor&&) = default;
+  XPtrTorchOptionalTensor& operator=(const XPtrTorchOptionalTensor&) = default;
+  XPtrTorchOptionalTensor& operator=(XPtrTorchOptionalTensor&&) = default;
   explicit XPtrTorchOptionalTensor(SEXP x);
   operator SEXP() const;
 };
@@ -82,6 +97,9 @@ class XPtrTorchTensorList : public XPtrTorch {
   explicit XPtrTorchTensorList(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchTensorList(const XPtrTorchTensorList& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchTensorList(XPtrTorchTensorList&&) = default;
+  XPtrTorchTensorList& operator=(const XPtrTorchTensorList&) = default;
+  XPtrTorchTensorList& operator=(XPtrTorchTensorList&&) = default;
   explicit XPtrTorchTensorList(SEXP x);
   operator SEXP() const;
 };
@@ -104,6 +122,9 @@ class XPtrTorchIndexTensorList : public XPtrTorch {
   explicit XPtrTorchIndexTensorList(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchIndexTensorList(const XPtrTorchIndexTensorList& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchIndexTensorList(XPtrTorchIndexTensorList&&) = default;
+  XPtrTorchIndexTensorList& operator=(const XPtrTorchIndexTensorList&) = default;
+  XPtrTorchIndexTensorList& operator=(XPtrTorchIndexTensorList&&) = default;
   explicit XPtrTorchIndexTensorList(SEXP x);
 };
 
@@ -115,6 +136,9 @@ class XPtrTorchOptionalIndexTensorList : public XPtrTorch {
       : XPtrTorch(x) {}
   XPtrTorchOptionalIndexTensorList(const XPtrTorchOptionalIndexTensorList& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchOptionalIndexTensorList(XPtrTorchOptionalIndexTensorList&&) = default;
+  XPtrTorchOptionalIndexTensorList& operator=(const XPtrTorchOptionalIndexTensorList&) = default;
+  XPtrTorchOptionalIndexTensorList& operator=(XPtrTorchOptionalIndexTensorList&&) = default;
   explicit XPtrTorchOptionalIndexTensorList(SEXP x);
 };
 
@@ -124,6 +148,9 @@ class XPtrTorchScalarType : public XPtrTorch {
   explicit XPtrTorchScalarType(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchScalarType(const XPtrTorchScalarType& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchScalarType(XPtrTorchScalarType&&) = default;
+  XPtrTorchScalarType& operator=(const XPtrTorchScalarType&) = default;
+  XPtrTorchScalarType& operator=(XPtrTorchScalarType&&) = default;
   XPtrTorchScalarType(SEXP x);
   operator SEXP() const;
 };
@@ -142,6 +169,9 @@ class XPtrTorchScalar : public XPtrTorch {
   XPtrTorchScalar(void* x) : XPtrTorch(x, delete_scalar) {}
   explicit XPtrTorchScalar(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchScalar(const XPtrTorchScalar& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchScalar(XPtrTorchScalar&&) = default;
+  XPtrTorchScalar& operator=(const XPtrTorchScalar&) = default;
+  XPtrTorchScalar& operator=(XPtrTorchScalar&&) = default;
   explicit XPtrTorchScalar(SEXP x);
   operator SEXP() const;
 };
@@ -152,6 +182,9 @@ class XPtrTorchTensorOptions : public XPtrTorch {
   explicit XPtrTorchTensorOptions(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchTensorOptions(const XPtrTorchTensorOptions& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchTensorOptions(XPtrTorchTensorOptions&&) = default;
+  XPtrTorchTensorOptions& operator=(const XPtrTorchTensorOptions&) = default;
+  XPtrTorchTensorOptions& operator=(XPtrTorchTensorOptions&&) = default;
   explicit XPtrTorchTensorOptions(SEXP x);
   operator SEXP() const;
 };
@@ -161,6 +194,9 @@ class XPtrTorchDevice : public XPtrTorch {
   XPtrTorchDevice(void* x) : XPtrTorch(x, delete_device) {}
   explicit XPtrTorchDevice(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchDevice(const XPtrTorchDevice& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchDevice(XPtrTorchDevice&&) = default;
+  XPtrTorchDevice& operator=(const XPtrTorchDevice&) = default;
+  XPtrTorchDevice& operator=(XPtrTorchDevice&&) = default;
   explicit XPtrTorchDevice(SEXP x);
   operator SEXP() const;
 };
@@ -171,6 +207,9 @@ class XPtrTorchOptionalDevice : public XPtrTorch {
   explicit XPtrTorchOptionalDevice(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchOptionalDevice(const XPtrTorchOptionalDevice& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchOptionalDevice(XPtrTorchOptionalDevice&&) = default;
+  XPtrTorchOptionalDevice& operator=(const XPtrTorchOptionalDevice&) = default;
+  XPtrTorchOptionalDevice& operator=(XPtrTorchOptionalDevice&&) = default;
   explicit XPtrTorchOptionalDevice(SEXP x);
   operator SEXP() const;
 };
@@ -181,6 +220,9 @@ class XPtrTorchDtype : public XPtrTorch {
   XPtrTorchDtype(void* x) : XPtrTorch(x, delete_dtype) {}
   explicit XPtrTorchDtype(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchDtype(const XPtrTorchDtype& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchDtype(XPtrTorchDtype&&) = default;
+  XPtrTorchDtype& operator=(const XPtrTorchDtype&) = default;
+  XPtrTorchDtype& operator=(XPtrTorchDtype&&) = default;
   explicit XPtrTorchDtype(SEXP x);
   operator SEXP() const;
 };
@@ -190,6 +232,9 @@ class XPtrTorchDimname : public XPtrTorch {
   XPtrTorchDimname(void* x) : XPtrTorch(x, delete_dimname) {}
   explicit XPtrTorchDimname(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchDimname(const XPtrTorchDimname& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchDimname(XPtrTorchDimname&&) = default;
+  XPtrTorchDimname& operator=(const XPtrTorchDimname&) = default;
+  XPtrTorchDimname& operator=(XPtrTorchDimname&&) = default;
   explicit XPtrTorchDimname(SEXP x);
   explicit XPtrTorchDimname(const std::string& x)
       : XPtrTorchDimname(Rcpp::wrap(x)) {}
@@ -202,6 +247,9 @@ class XPtrTorchDimnameList : public XPtrTorch {
   explicit XPtrTorchDimnameList(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchDimnameList(const XPtrTorchDimnameList& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchDimnameList(XPtrTorchDimnameList&&) = default;
+  XPtrTorchDimnameList& operator=(const XPtrTorchDimnameList&) = default;
+  XPtrTorchDimnameList& operator=(XPtrTorchDimnameList&&) = default;
   explicit XPtrTorchDimnameList(SEXP x);
   operator SEXP() const;
 };
@@ -214,6 +262,9 @@ class XPtrTorchOptionalDimnameList : public XPtrTorch {
       : XPtrTorch(x) {}
   XPtrTorchOptionalDimnameList(const XPtrTorchOptionalDimnameList& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchOptionalDimnameList(XPtrTorchOptionalDimnameList&&) = default;
+  XPtrTorchOptionalDimnameList& operator=(const XPtrTorchOptionalDimnameList&) = default;
+  XPtrTorchOptionalDimnameList& operator=(XPtrTorchOptionalDimnameList&&) = default;
   explicit XPtrTorchOptionalDimnameList(SEXP x);
   operator SEXP() const;
 };
@@ -226,6 +277,9 @@ class XPtrTorchjit_named_parameter_list : public XPtrTorch {
       : XPtrTorch(x) {}
   XPtrTorchjit_named_parameter_list(const XPtrTorchjit_named_parameter_list& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchjit_named_parameter_list(XPtrTorchjit_named_parameter_list&&) = default;
+  XPtrTorchjit_named_parameter_list& operator=(const XPtrTorchjit_named_parameter_list&) = default;
+  XPtrTorchjit_named_parameter_list& operator=(XPtrTorchjit_named_parameter_list&&) = default;
   operator SEXP() const;
 };
 
@@ -237,6 +291,9 @@ class XPtrTorchjit_named_buffer_list : public XPtrTorch {
       : XPtrTorch(x) {}
   XPtrTorchjit_named_buffer_list(const XPtrTorchjit_named_buffer_list& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchjit_named_buffer_list(XPtrTorchjit_named_buffer_list&&) = default;
+  XPtrTorchjit_named_buffer_list& operator=(const XPtrTorchjit_named_buffer_list&) = default;
+  XPtrTorchjit_named_buffer_list& operator=(XPtrTorchjit_named_buffer_list&&) = default;
   operator SEXP() const;
 };
 
@@ -248,6 +305,9 @@ class XPtrTorchjit_named_module_list : public XPtrTorch {
       : XPtrTorch(x) {}
   XPtrTorchjit_named_module_list(const XPtrTorchjit_named_module_list& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchjit_named_module_list(XPtrTorchjit_named_module_list&&) = default;
+  XPtrTorchjit_named_module_list& operator=(const XPtrTorchjit_named_module_list&) = default;
+  XPtrTorchjit_named_module_list& operator=(XPtrTorchjit_named_module_list&&) = default;
   operator SEXP() const;
 };
 
@@ -256,6 +316,9 @@ class XPtrTorchGenerator : public XPtrTorch {
   XPtrTorchGenerator(void* x) : XPtrTorch(x, delete_generator) {}
   explicit XPtrTorchGenerator(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchGenerator(const XPtrTorchGenerator& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchGenerator(XPtrTorchGenerator&&) = default;
+  XPtrTorchGenerator& operator=(const XPtrTorchGenerator&) = default;
+  XPtrTorchGenerator& operator=(XPtrTorchGenerator&&) = default;
   explicit XPtrTorchGenerator(SEXP x);
   operator SEXP() const;
 };
@@ -267,6 +330,9 @@ class XPtrTorchOptionalGenerator : public XPtrTorch {
   explicit XPtrTorchOptionalGenerator(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchOptionalGenerator(const XPtrTorchOptionalGenerator& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchOptionalGenerator(XPtrTorchOptionalGenerator&&) = default;
+  XPtrTorchOptionalGenerator& operator=(const XPtrTorchOptionalGenerator&) = default;
+  XPtrTorchOptionalGenerator& operator=(XPtrTorchOptionalGenerator&&) = default;
   explicit XPtrTorchOptionalGenerator(SEXP x);
   operator SEXP() const;
 };
@@ -278,6 +344,9 @@ class XPtrTorchMemoryFormat : public XPtrTorch {
   explicit XPtrTorchMemoryFormat(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchMemoryFormat(const XPtrTorchMemoryFormat& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchMemoryFormat(XPtrTorchMemoryFormat&&) = default;
+  XPtrTorchMemoryFormat& operator=(const XPtrTorchMemoryFormat&) = default;
+  XPtrTorchMemoryFormat& operator=(XPtrTorchMemoryFormat&&) = default;
   explicit XPtrTorchMemoryFormat(SEXP x);
   operator SEXP() const;
 };
@@ -289,6 +358,9 @@ class XPtrTorchIntArrayRef : public XPtrTorch {
   explicit XPtrTorchIntArrayRef(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchIntArrayRef(const XPtrTorchIntArrayRef& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchIntArrayRef(XPtrTorchIntArrayRef&&) = default;
+  XPtrTorchIntArrayRef& operator=(const XPtrTorchIntArrayRef&) = default;
+  XPtrTorchIntArrayRef& operator=(XPtrTorchIntArrayRef&&) = default;
   explicit XPtrTorchIntArrayRef(SEXP x);
   operator SEXP() const;
 };
@@ -300,6 +372,9 @@ class XPtrTorchSymIntArrayRef : public XPtrTorch {
   explicit XPtrTorchSymIntArrayRef(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchSymIntArrayRef(const XPtrTorchSymIntArrayRef& x)
     : XPtrTorch(x.get_shared()) {}
+  XPtrTorchSymIntArrayRef(XPtrTorchSymIntArrayRef&&) = default;
+  XPtrTorchSymIntArrayRef& operator=(const XPtrTorchSymIntArrayRef&) = default;
+  XPtrTorchSymIntArrayRef& operator=(XPtrTorchSymIntArrayRef&&) = default;
   explicit XPtrTorchSymIntArrayRef(SEXP x);
   // operator SEXP() const;
 };
@@ -311,6 +386,9 @@ class XPtrTorchSymInt : public XPtrTorch {
   explicit XPtrTorchSymInt(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchSymInt(const XPtrTorchSymInt& x)
     : XPtrTorch(x.get_shared()) {}
+  XPtrTorchSymInt(XPtrTorchSymInt&&) = default;
+  XPtrTorchSymInt& operator=(const XPtrTorchSymInt&) = default;
+  XPtrTorchSymInt& operator=(XPtrTorchSymInt&&) = default;
   explicit XPtrTorchSymInt(SEXP x);
   // operator SEXP() const;
 };
@@ -323,6 +401,9 @@ class XPtrTorchFunctionPtr : public XPtrTorch {
   explicit XPtrTorchFunctionPtr(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchFunctionPtr(const XPtrTorchFunctionPtr& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchFunctionPtr(XPtrTorchFunctionPtr&&) = default;
+  XPtrTorchFunctionPtr& operator=(const XPtrTorchFunctionPtr&) = default;
+  XPtrTorchFunctionPtr& operator=(XPtrTorchFunctionPtr&&) = default;
 };
 
 class XPtrTorchIndexIntArrayRef : public XPtrTorch {
@@ -332,6 +413,9 @@ class XPtrTorchIndexIntArrayRef : public XPtrTorch {
   explicit XPtrTorchIndexIntArrayRef(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchIndexIntArrayRef(const XPtrTorchIndexIntArrayRef& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchIndexIntArrayRef(XPtrTorchIndexIntArrayRef&&) = default;
+  XPtrTorchIndexIntArrayRef& operator=(const XPtrTorchIndexIntArrayRef&) = default;
+  XPtrTorchIndexIntArrayRef& operator=(XPtrTorchIndexIntArrayRef&&) = default;
   explicit XPtrTorchIndexIntArrayRef(SEXP x);
 };
 
@@ -406,6 +490,9 @@ class XPtrTorchvector_string : public XPtrTorch {
   XPtrTorchvector_string(SEXP x);
   XPtrTorchvector_string(const XPtrTorchvector_string& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchvector_string(XPtrTorchvector_string&&) = default;
+  XPtrTorchvector_string& operator=(const XPtrTorchvector_string&) = default;
+  XPtrTorchvector_string& operator=(XPtrTorchvector_string&&) = default;
   XPtrTorchvector_string(void* x) : XPtrTorch(x, delete_vector_string) {}
   operator SEXP() const;
 };
@@ -415,6 +502,9 @@ class XPtrTorchstring : public XPtrTorch {
   XPtrTorchstring(void* x) : XPtrTorch(x, delete_string) {}
   XPtrTorchstring(SEXP x);
   XPtrTorchstring(const XPtrTorchstring& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchstring(XPtrTorchstring&&) = default;
+  XPtrTorchstring& operator=(const XPtrTorchstring&) = default;
+  XPtrTorchstring& operator=(XPtrTorchstring&&) = default;
   XPtrTorchstring(std::string x)
       : XPtrTorchstring(fixme_new_string(x.c_str(), x.size())) {}
   operator SEXP() const;
@@ -427,6 +517,9 @@ class XPtrTorchstring_view : public XPtrTorch {
   XPtrTorchstring_view(SEXP x);
   XPtrTorchstring_view(const XPtrTorchstring_view& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchstring_view(XPtrTorchstring_view&&) = default;
+  XPtrTorchstring_view& operator=(const XPtrTorchstring_view&) = default;
+  XPtrTorchstring_view& operator=(XPtrTorchstring_view&&) = default;
 };
 
 class XPtrTorchoptional_string_view : public XPtrTorch {
@@ -460,6 +553,9 @@ class XPtrTorchIValue : public XPtrTorch {
   XPtrTorchIValue(void* x) : XPtrTorch(x, delete_ivalue) {}
   explicit XPtrTorchIValue(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchIValue(const XPtrTorchIValue& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchIValue(XPtrTorchIValue&&) = default;
+  XPtrTorchIValue& operator=(const XPtrTorchIValue&) = default;
+  XPtrTorchIValue& operator=(XPtrTorchIValue&&) = default;
   XPtrTorchIValue(SEXP x);
   operator SEXP() const;
 };
@@ -470,6 +566,9 @@ class XPtrTorchFunctionSchema : public XPtrTorch {
   explicit XPtrTorchFunctionSchema(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchFunctionSchema(const XPtrTorchFunctionSchema& x)
     : XPtrTorch(x.get_shared()) {}
+  XPtrTorchFunctionSchema(XPtrTorchFunctionSchema&&) = default;
+  XPtrTorchFunctionSchema& operator=(const XPtrTorchFunctionSchema&) = default;
+  XPtrTorchFunctionSchema& operator=(XPtrTorchFunctionSchema&&) = default;
   XPtrTorchFunctionSchema(SEXP x);
   operator SEXP() const;
 };
@@ -480,6 +579,9 @@ class XPtrTorchFunctionSchemaList : public XPtrTorch {
   explicit XPtrTorchFunctionSchemaList(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchFunctionSchemaList(const XPtrTorchFunctionSchemaList& x)
     : XPtrTorch(x.get_shared()) {}
+  XPtrTorchFunctionSchemaList(XPtrTorchFunctionSchemaList&&) = default;
+  XPtrTorchFunctionSchemaList& operator=(const XPtrTorchFunctionSchemaList&) = default;
+  XPtrTorchFunctionSchemaList& operator=(XPtrTorchFunctionSchemaList&&) = default;
   XPtrTorchFunctionSchemaList(SEXP x);
   operator SEXP() const;
 };
@@ -490,6 +592,9 @@ class XPtrTorchFunctionSchemaArgument : public XPtrTorch {
   explicit XPtrTorchFunctionSchemaArgument(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchFunctionSchemaArgument(const XPtrTorchFunctionSchemaArgument& x)
     : XPtrTorch(x.get_shared()) {}
+  XPtrTorchFunctionSchemaArgument(XPtrTorchFunctionSchemaArgument&&) = default;
+  XPtrTorchFunctionSchemaArgument& operator=(const XPtrTorchFunctionSchemaArgument&) = default;
+  XPtrTorchFunctionSchemaArgument& operator=(XPtrTorchFunctionSchemaArgument&&) = default;
   XPtrTorchFunctionSchemaArgument(SEXP x);
   operator SEXP() const;
 };
@@ -500,6 +605,9 @@ class XPtrTorchFunctionSchemaArgumentList : public XPtrTorch {
   explicit XPtrTorchFunctionSchemaArgumentList(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchFunctionSchemaArgumentList(const XPtrTorchFunctionSchemaArgumentList& x)
     : XPtrTorch(x.get_shared()) {}
+  XPtrTorchFunctionSchemaArgumentList(XPtrTorchFunctionSchemaArgumentList&&) = default;
+  XPtrTorchFunctionSchemaArgumentList& operator=(const XPtrTorchFunctionSchemaArgumentList&) = default;
+  XPtrTorchFunctionSchemaArgumentList& operator=(XPtrTorchFunctionSchemaArgumentList&&) = default;
   XPtrTorchFunctionSchemaArgumentList(SEXP x);
   operator SEXP() const;
 };
@@ -509,6 +617,9 @@ class XPtrTorchTuple : public XPtrTorch {
  public:
   XPtrTorchTuple(void* x) : XPtrTorch(x, delete_tuple) {}
   XPtrTorchTuple(const XPtrTorchTuple& x) : XPtrTorch(x.get_shared()) {}
+  XPtrTorchTuple(XPtrTorchTuple&&) = default;
+  XPtrTorchTuple& operator=(const XPtrTorchTuple&) = default;
+  XPtrTorchTuple& operator=(XPtrTorchTuple&&) = default;
   XPtrTorchTuple(SEXP x);
   operator SEXP() const;
 };
@@ -527,6 +638,9 @@ class XPtrTorchvector_Scalar : public XPtrTorch {
   XPtrTorchvector_Scalar(SEXP x);
   XPtrTorchvector_Scalar(const XPtrTorchvector_Scalar& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchvector_Scalar(XPtrTorchvector_Scalar&&) = default;
+  XPtrTorchvector_Scalar& operator=(const XPtrTorchvector_Scalar&) = default;
+  XPtrTorchvector_Scalar& operator=(XPtrTorchvector_Scalar&&) = default;
 };
 
 class XPtrTorchvector_int64_t : public XPtrTorch {
@@ -582,6 +696,9 @@ class XPtrTorchCompilationUnit : public XPtrTorch {
   explicit XPtrTorchCompilationUnit(std::shared_ptr<void> x) : XPtrTorch(x) {}
   XPtrTorchCompilationUnit(const XPtrTorchCompilationUnit& x)
       : XPtrTorch(x.get_shared()) {}
+  XPtrTorchCompilationUnit(XPtrTorchCompilationUnit&&) = default;
+  XPtrTorchCompilationUnit& operator=(const XPtrTorchCompilationUnit&) = default;
+  XPtrTorchCompilationUnit& operator=(XPtrTorchCompilationUnit&&) = default;
   operator SEXP() const;
 };
 

--- a/inst/include/torch_types.h
+++ b/inst/include/torch_types.h
@@ -17,7 +17,7 @@ class XPtrTorch {
       : XPtrTorch(std::shared_ptr<void>(x, deleter)) {}
   explicit XPtrTorch(std::shared_ptr<void> x) : ptr(x) {}
   void* get() const { return ptr.get(); }
-  std::shared_ptr<void> get_shared() const { return ptr; }
+  const std::shared_ptr<void>& get_shared() const { return ptr; }
 };
 
 class XPtrTorchIndexTensor : public XPtrTorch {

--- a/inst/include/utils.h
+++ b/inst/include/utils.h
@@ -123,13 +123,13 @@ public:
 
 template <class type>
 Rcpp::XPtr<type> make_xptr(type x) {
-  auto* out = new type(x);
+  auto* out = new type(std::move(x));
   return Rcpp::XPtr<type>(out);
 }
 
 template <class type>
 Rcpp::XPtr<type> make_xptr(type x, std::string dyn_type) {
-  auto* out = new type(x);
+  auto* out = new type(std::move(x));
   auto ptr = Rcpp::XPtr<type>(out);
   ptr.attr("dynamic_type") = dyn_type;
   return ptr;


### PR DESCRIPTION
## Summary
- **`get_shared()` returns `const&`** instead of by value, eliminating one atomic refcount increment per call
- **Add default move constructors** to all 39 `XPtrTorch` subclasses that declare explicit copy constructors. C++ suppresses the implicit move constructor when a copy constructor is user-declared, so without these, passing temporaries falls back to copying (atomic refcount ops) instead of free pointer swaps
- **Add default copy/move assignment operators** alongside move constructors (required by the Rule of Five — declaring a move constructor suppresses implicit copy assignment)
- **`make_xptr` uses `std::move`** to avoid a redundant `shared_ptr` copy when wrapping objects into R external pointers

## Test plan
- [x] `devtools::test()` passes (2971 tests, 0 failures)
- [x] Benchmarked `torch_add(x, y)` on 2x2 tensors — per-call improvement is within noise (~12.5µs) since the R-to-C++ FFI boundary dominates, but the changes eliminate unnecessary atomic operations in the C++ layer