### PR TITLE
Add Python comparison to CPU cache benchmark

### DIFF
--- a/bench/benchmark_cpu_cache/benchmark.py
+++ b/bench/benchmark_cpu_cache/benchmark.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import torch.optim as optim
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--latent", type=int, default=5000)
+parser.add_argument("--latent", type=int, default=500)
 args = parser.parse_args()
 
 print(f"PyTorch version: {torch.__version__}")

--- a/bench/benchmark_cpu_cache/benchmark_latent.R
+++ b/bench/benchmark_cpu_cache/benchmark_latent.R
@@ -60,21 +60,27 @@ for (latent in latent_sizes) {
   }
 }
 
-# Print table
-cat("\n=== Results ===\n")
+# Print markdown table
+cat("\n## Results\n\n")
 has_python <- "Python PyTorch" %in% results$mode
-header <- sprintf("%-8s %16s %16s %8s", "latent", "cache enabled", "cache disabled", "speedup")
-if (has_python) header <- paste0(header, sprintf(" %16s %8s", "Python", "R/Python"))
+
+header <- "| Latent | Cache enabled | Cache disabled | Cache speedup |"
+sep    <- "|--------|---------------|----------------|---------------|"
+if (has_python) {
+  header <- paste0(header, " Python | R/Python |")
+  sep    <- paste0(sep, "--------|----------|")
+}
 cat(header, "\n")
+cat(sep, "\n")
 
 for (latent in latent_sizes) {
   enabled <- results$mean_s[results$latent == latent & results$mode == "cache enabled"]
   disabled <- results$mean_s[results$latent == latent & results$mode == "cache disabled"]
-  line <- sprintf("%-8d %13.3f s %13.3f s %7.2fx", latent, enabled, disabled, disabled / enabled)
+  line <- sprintf("| %d | %.3fs | %.3fs | %.2fx |", latent, enabled, disabled, disabled / enabled)
   if (has_python) {
     python_t <- results$mean_s[results$latent == latent & results$mode == "Python PyTorch"]
     if (length(python_t) > 0) {
-      line <- paste0(line, sprintf(" %13.3f s %7.2fx", python_t, enabled / python_t))
+      line <- paste0(line, sprintf(" %.3fs | %.2fx |", python_t, enabled / python_t))
     }
   }
   cat(line, "\n")

--- a/bench/benchmark_cpu_cache/benchmark_latent.R
+++ b/bench/benchmark_cpu_cache/benchmark_latent.R
@@ -2,6 +2,7 @@ library(ggplot2)
 
 DIR <- normalizePath(dirname(sub("--file=", "", grep("--file=", commandArgs(FALSE), value = TRUE))))
 benchmark_script <- file.path(DIR, "benchmark.R")
+benchmark_py <- file.path(DIR, "benchmark.py")
 
 latent_sizes <- c(10, 50, 100, 500, 1000, 2000, 5000)
 
@@ -11,6 +12,14 @@ parse_output <- function(lines) {
   m <- regmatches(mean_line, regexec("mean=([0-9.]+)s\\s+se=([0-9.]+)s", mean_line))[[1]]
   list(mean = as.numeric(m[2]), se = as.numeric(m[3]))
 }
+
+# Check if uv is available for running Python benchmarks
+python_available <- tryCatch({
+  out <- system2("uv", c("run", "--with", "torch==2.8.0", "--with", "numpy",
+                          "python", "-c", "import torch; print(torch.__version__)"),
+                 stdout = TRUE, stderr = TRUE)
+  length(out) > 0 && !any(grepl("Error|error|No module", out))
+}, error = function(e) FALSE)
 
 results <- data.frame()
 
@@ -32,15 +41,43 @@ for (latent in latent_sizes) {
       stringsAsFactors = FALSE
     ))
   }
+
+  if (python_available) {
+    cat(sprintf("Running: latent=%d Python\n", latent))
+    out <- system2("uv", c("run", "--with", "torch==2.8.0", "--with", "numpy",
+                            "python", benchmark_py, sprintf("--latent=%d", latent)),
+                   stdout = TRUE, stderr = TRUE)
+    cat(out, sep = "\n")
+
+    parsed <- parse_output(out)
+    results <- rbind(results, data.frame(
+      latent = latent,
+      mode = "Python PyTorch",
+      mean_s = parsed$mean,
+      se_s = parsed$se,
+      stringsAsFactors = FALSE
+    ))
+  }
 }
 
 # Print table
 cat("\n=== Results ===\n")
-cat(sprintf("%-8s %16s %16s %8s\n", "latent", "cache enabled", "cache disabled", "speedup"))
+has_python <- "Python PyTorch" %in% results$mode
+header <- sprintf("%-8s %16s %16s %8s", "latent", "cache enabled", "cache disabled", "speedup")
+if (has_python) header <- paste0(header, sprintf(" %16s %8s", "Python", "R/Python"))
+cat(header, "\n")
+
 for (latent in latent_sizes) {
   enabled <- results$mean_s[results$latent == latent & results$mode == "cache enabled"]
   disabled <- results$mean_s[results$latent == latent & results$mode == "cache disabled"]
-  cat(sprintf("%-8d %13.3f s %13.3f s %7.2fx\n", latent, enabled, disabled, disabled / enabled))
+  line <- sprintf("%-8d %13.3f s %13.3f s %7.2fx", latent, enabled, disabled, disabled / enabled)
+  if (has_python) {
+    python_t <- results$mean_s[results$latent == latent & results$mode == "Python PyTorch"]
+    if (length(python_t) > 0) {
+      line <- paste0(line, sprintf(" %13.3f s %7.2fx", python_t, enabled / python_t))
+    }
+  }
+  cat(line, "\n")
 }
 
 # Plot
@@ -51,8 +88,8 @@ p <- ggplot(results, aes(x = latent, y = mean_s, fill = mode)) +
   geom_errorbar(aes(ymin = mean_s - se_s, ymax = mean_s + se_s),
                 position = position_dodge(width = 0.9), width = 0.3) +
   labs(
-    title = "Training loop time: cache enabled vs disabled by hidden layer size",
-    subtitle = "2-layer NN (100 → latent → 1), Adam, 1000 steps, CPU.",
+    title = "Training loop time by hidden layer size",
+    subtitle = "2-layer NN (100 -> latent -> 1), Adam, 1000 steps, CPU.",
     x = "Hidden layer size",
     y = "Total time (s)",
     fill = ""

--- a/bench/benchmark_cpu_cache/run.sh
+++ b/bench/benchmark_cpu_cache/run.sh
@@ -1,24 +1,27 @@
 #!/bin/bash
-# Benchmark CPU block cache: enabled vs disabled
+# Benchmark CPU block cache: enabled vs disabled, plus Python comparison
 # Usage: bash bench/benchmark_cpu_cache/run.sh
+# Override latent sizes: LATENT_SIZES="500 2000 5000" bash bench/benchmark_cpu_cache/run.sh
 
 set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
-LATENT="${LATENT:-500}"
+LATENT_SIZES="${LATENT_SIZES:-500 2000 5000}"
 
-echo "============================================"
-echo "1/3  R torch (cache enabled)"
-echo "============================================"
-Rscript "$DIR/benchmark.R" --latent="$LATENT"
+for LATENT in $LATENT_SIZES; do
+  echo ""
+  echo "============================================"
+  echo "  latent=$LATENT"
+  echo "============================================"
 
-echo ""
-echo "============================================"
-echo "2/3  Cache disabled"
-echo "============================================"
-Rscript "$DIR/benchmark.R" --no-cache --latent="$LATENT"
+  echo ""
+  echo "--- R torch (cache enabled) ---"
+  Rscript "$DIR/benchmark.R" --latent="$LATENT"
 
-echo ""
-echo "============================================"
-echo "3/3  Python (PyTorch 2.8.0)"
-echo "============================================"
-uv run --with torch==2.8.0 --with numpy python "$DIR/benchmark.py" --latent="$LATENT"
+  echo ""
+  echo "--- R torch (cache disabled) ---"
+  Rscript "$DIR/benchmark.R" --no-cache --latent="$LATENT"
+
+  echo ""
+  echo "--- Python PyTorch ---"
+  uv run --with torch==2.8.0 --with numpy python "$DIR/benchmark.py" --latent="$LATENT"
+done


### PR DESCRIPTION
## Summary

- `run.sh`: run benchmarks at multiple latent sizes (500, 2000, 5000) to show how the R/Python gap narrows with model size
- `benchmark_latent.R`: include Python PyTorch results in the summary table and plot when `uv` is available
- `benchmark.py`: default latent from 5000 to 500 to match R default

All Python runs use `uv run --with torch==2.8.0 --with numpy` as before.

## Context

Profiling on Linux showed that R torch reaches near-parity with Python PyTorch at larger model sizes (latent >= 2000). The remaining gap at small sizes is fixed R-level dispatch overhead (~18us/op) that becomes negligible as tensor computation scales. Adding the Python comparison to the benchmark makes this visible.

## Test plan

- [ ] `bash bench/benchmark_cpu_cache/run.sh` runs all three variants at each latent size
- [ ] `Rscript bench/benchmark_cpu_cache/benchmark_latent.R` produces table + plot with Python column