### PR TITLE
Remove unused .torch_normal generated binding

### DIFF
--- a/R/gen-namespace.R
+++ b/R/gen-namespace.R
@@ -10464,12 +10464,6 @@ torch_norm_out <- function(out, self, p = 2L, dim, keepdim = FALSE, dtype) {
 }
 
 
-#' @rdname .torch_normal
-.torch_normal <- function(mean, std = 1L, size, generator = NULL, options = list()) {
-  cpp_torch_dispatch_namespace_normal(mget(x = c("mean", "std", "size", "generator", "options")))
-}
-
-
 #' @rdname torch_normal_functional
 torch_normal_functional <- function(self, mean = 0L, std = 1L, generator = NULL) {
   cpp_torch_namespace_normal_functional_self_Tensor(self, mean, std, generator)

--- a/tools/torchgen/R/r.R
+++ b/tools/torchgen/R/r.R
@@ -131,7 +131,7 @@ internal_funs <- c("logical_not", "max_pool1d_with_indices", "max_pool2d_with_in
                    "max_pool2d_with_indices_out", "max_pool3d_with_indices",
                    "max_pool3d_with_indices_out", "max", "min", "max_out", "min_out",
                    "nll_loss", "nll_loss2d", "bartlett_window", "blackman_window",
-                   "hamming_window", "hann_window", "normal",
+                   "hamming_window", "hann_window",
                    "result_type", "sparse_coo_tensor", "stft",
                    "tensordot", "tril_indices", "triu_indices",
                    "multilabel_margin_loss", "multi_margin_loss",


### PR DESCRIPTION
## Summary
- `.torch_normal` in `gen-namespace.R` called `cpp_torch_dispatch_namespace_normal`, a C++ binding that was never generated, causing an R CMD check NOTE.
- The function was dead code — `torch_normal` in `wrapers.R` handles all dispatch directly without using `.torch_normal`.
- Removed "normal" from `internal_funs` in the codegen so it's consistently skipped on both R and C++ sides.

## Test plan
- [x] Verified `.torch_normal` is no longer generated
- [x] Verified `torch_normal` (the manual wrapper) is unaffected
- [x] Confirmed no other code references `.torch_normal`