### PR TITLE
Add memory management functions to pkgdown index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -192,3 +192,7 @@ reference:
   - title: Contrib
     contents:
       - contrib_sort_vertices
+  - title: Memory management
+    contents:
+      - set_cpu_allocator_config
+      - cpu_cache_flush


### PR DESCRIPTION
## Summary
- Adds `set_cpu_allocator_config` and `cpu_cache_flush` to the pkgdown reference index under a new "Memory management" section.

## Test plan
- [ ] Verify pkgdown site builds successfully with the new entries.