### PR TITLE
Prepend install lib dir to PATH on Windows so cuDNN sub-DLLs resolve

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 - Multi-worker dataloaders now use POSIX shared memory for tensor transfer on
   Unix systems, resulting in up to 2x faster data loading. To revert to the
   previous behavior, set `options(torch.dataloader_use_shm = FALSE)`. (#1456)
+- On Windows, the install lib directory is now prepended to `PATH` at load so
+  cuDNN's lazily-loaded sub-DLLs (e.g. `cudnn_graph64_9.dll`) resolve; cuDNN-backed
+  CUDA ops previously failed with "Could not locate cudnn_graph64_9.dll".
 
 # torch 0.17.0
 

--- a/R/lantern_load.R
+++ b/R/lantern_load.R
@@ -41,7 +41,21 @@ lantern_start <- function(reload = FALSE) {
   }
 
   load_cudatoolkit_libs()
-  cpp_lantern_init(file.path(torch_install_path(), "lib"))
+
+  lib_path <- file.path(torch_install_path(), "lib")
+  if (is_windows()) {
+    # cuDNN 9 is split across several DLLs. cuDNN's lazy sub-DLL load (e.g.
+    # cudnn_graph64_9.dll) does not find the install lib dir unless it is on
+    # PATH, so cuDNN-backed CUDA ops otherwise fail with "Could not locate
+    # cudnn_graph64_9.dll" even though the DLL is present here. Prepend lib_path
+    # (once) so those loads resolve.
+    path_dirs <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1]]
+    if (!any(normalizePath(path_dirs, winslash = "/", mustWork = FALSE) ==
+             normalizePath(lib_path, winslash = "/", mustWork = FALSE))) {
+      Sys.setenv(PATH = paste(lib_path, Sys.getenv("PATH"), sep = ";"))
+    }
+  }
+  cpp_lantern_init(lib_path)
 
   log_enabled <- as.integer(Sys.getenv("TORCH_LOG", "0"))
   cpp_lantern_configure(log_enabled)


### PR DESCRIPTION
Addresses the Windows cuDNN DLL load failure tracked in #1287 (the `Could not locate cudnn_graph64_9.dll` reports there).

## Problem

On Windows CUDA installs, cuDNN-backed ops fail at runtime even though every cuDNN 9 DLL is present in `<install>/torch/lib`:

```r
library(torch)
x <- torch_randn(1, 3, 16, 16, device = "cuda")
w <- torch_randn(4, 3, 3, 3, device = "cuda")
nnf_conv2d(x, w)
#> Could not locate cudnn_graph64_9.dll. Please make sure it is in your library path!
#> Invalid handle. Cannot load symbol cudnnCreate
```

`cuda_is_available()` is `TRUE` and non-cuDNN CUDA ops (e.g. `torch_mm`) work. This lines up with the diagnosis in #1287 that the loader isn't finding `torch/lib`.

## Cause

cuDNN 9 is split across several DLLs. `lanternLoadLibrary` loads `lantern.dll` with `LoadLibraryEx(..., LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)`, which resolves the static dependency chain (libtorch, `cudnn64_9.dll`) from the install lib dir. But `cudnn64_9.dll` then lazily loads `cudnn_graph64_9.dll` by name, and that load does not find the install lib dir unless it is on `PATH`.

## Fix

Prepend the install lib dir to `PATH` at load on Windows, so cuDNN's by-name sub-DLL loads resolve. This mirrors the existing `load_cudatoolkit_libs()` handling, which already does the same `Sys.setenv(PATH = ...)` for the separate cudatoolkit-package case. The prepend is idempotent, so repeated `library()`/reload calls don't grow `PATH`.

## Verification

Prepending `torch/lib` to `PATH` resolves the failure on torch 0.17.0 / libtorch 2.8.0+cu126, Windows 10, R 4.6.0 and R-devel: `nnf_conv2d` and a full `torch_scaled_dot_product_attention` forward then run and return correct results on GPU.

Refs #1287
