### PR TITLE
Preserve tensor dtype when the left operand is an R scalar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 - On Windows, the install lib directory is now prepended to `PATH` at load so
   cuDNN's lazily-loaded sub-DLLs (e.g. `cudnn_graph64_9.dll`) resolve; cuDNN-backed
   CUDA ops previously failed with "Could not locate cudnn_graph64_9.dll".
+- Arithmetic with an R scalar on the left no longer promotes the result dtype:
+  `1 - t` keeps `t`'s dtype (e.g. bfloat16, int64) instead of upcasting to
+  float32, matching Python's scalar promotion semantics. (#1471)
 
 # torch 0.17.0
 

--- a/R/operators.R
+++ b/R/operators.R
@@ -1,3 +1,15 @@
+# Convert a non-tensor lhs operand for arithmetic. Length-1 numerics
+# become 0-dim tensors, which participate weakly in type promotion the
+# way Python scalars do: `1 - t` keeps t's dtype instead of promoting
+# to the scalar's dtype (e.g. bfloat16 -> float32, int64 -> float32).
+to_operand_tensor <- function(x, ref) {
+  if ((is.numeric(x) || is.logical(x)) && length(x) == 1L) {
+    torch_scalar_tensor(x, device = ref$device)
+  } else {
+    torch_tensor(x, device = ref$device)
+  }
+}
+
 #' @export
 `+.torch_tensor` <- function(e1, e2) {
   if (missing(e2)) {
@@ -5,7 +17,7 @@
   }
 
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_add(e1, e2)
@@ -19,7 +31,7 @@
   }
 
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_sub(e1, e2)
@@ -28,7 +40,7 @@
 #' @export
 `*.torch_tensor` <- function(e1, e2) {
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_mul(e1, e2)
@@ -37,7 +49,7 @@
 #' @export
 `/.torch_tensor` <- function(e1, e2) {
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_div(e1, e2)
@@ -46,7 +58,7 @@
 #' @export
 `^.torch_tensor` <- function(e1, e2) {
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_pow(e1, e2)
@@ -55,7 +67,7 @@
 #' @export
 `%%.torch_tensor` <- function(e1, e2) {
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_fmod(e1, e2)
@@ -64,7 +76,7 @@
 #' @export
 `%/%.torch_tensor` <- function(e1, e2) {
   if (!is_torch_tensor(e1)) {
-    e1 <- torch_tensor(e1, device = e2$device)
+    e1 <- to_operand_tensor(e1, e2)
   }
 
   torch_div(e1, e2, rounding_mode = "trunc")

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -406,3 +406,22 @@ test_that("mean works", {
   expect_tensor_shape(mean(x, dim = 1, keepdim = TRUE), c(1, 100))
   expect_tensor_shape(mean(x, dim = 2, keepdim = TRUE), c(20, 1))
 })
+
+test_that("lhs scalars do not promote the result dtype", {
+  x <- torch_ones(3, dtype = torch_bfloat16())
+  expect_true((1 - x)$dtype == torch_bfloat16())
+  expect_true((2 * x)$dtype == torch_bfloat16())
+  expect_true((1 + x)$dtype == torch_bfloat16())
+  expect_true((2^x)$dtype == torch_bfloat16())
+  expect_equal_to_r((1 - x)$to(dtype = torch_float()), rep(0, 3))
+
+  y <- torch_ones(3, dtype = torch_long())
+  expect_true((1L + y)$dtype == torch_long())
+  expect_true((5L %% y)$dtype == torch_long())
+  expect_true((5L %/% y)$dtype == torch_long())
+  # division of integer tensors still promotes to the default dtype
+  expect_true((1L / y)$dtype == torch_float())
+
+  # dimensioned lhs vectors keep dictating promotion
+  expect_true((c(1, 2, 3) - x)$dtype == torch_float())
+})


### PR DESCRIPTION
## Problem

Arithmetic with an R scalar on the **left** silently promotes reduced-precision and integer tensors:

```r
t <- torch_ones(3, dtype = torch_bfloat16())
(t - 1)$dtype   # BFloat16, as expected
(1 - t)$dtype   # Float  <- silently upcast
(1 - torch_ones(3, dtype = torch_long()))$dtype   # Float (PyTorch returns Long)
```

In Python, `1 - t` keeps `t`'s dtype because Python scalars participate weakly in type promotion.

This surfaced as a hard failure in a bfloat16 attention stack: an additive mask built with `1 - attention_mask` came out float32, and CUDA's fused `scaled_dot_product_attention` rejects a bias whose dtype doesn't match the query ("invalid dtype for bias - should match query's dtype").

## Cause

The operator methods wrap a non-tensor lhs with `torch_tensor(e1, ...)`, which yields a **dimensioned** (length-1, 1-d) tensor of the default dtype. libtorch lets dimensioned tensors dictate promotion, so float32 wins over bfloat16/int64. The rhs case never hits this path: `torch_sub(tensor, 1)` takes the Tensor-Scalar overload, which promotes weakly.

## Fix

Wrap length-1 numeric/logical lhs operands with `torch_scalar_tensor()` instead. 0-dim tensors promote weakly, exactly like Python scalars, so:

- `1 - bf16` stays BFloat16, `2 * half` stays Half
- `1L + long` stays Long, `5L %% long` stays Long
- `1L / long` still promotes to the default float dtype (division semantics unchanged)
- `c(1, 2, 3) - bf16` still promotes to Float (dimensioned vectors keep their old behavior)
- `NA`, `NaN`, logical, and integer scalars behave as before (verified against `torch_tensor()` conversions)

Applied to the seven arithmetic ops (`+`, `-`, `*`, `/`, `^`, `%%`, `%/%`). Comparison operators share the wrapping pattern but return bool, so they're left untouched.

The regression test fails 4 assertions before the patch and passes after; the rest of `test-operators.R` is unchanged (149 passing before and after, CPU and CUDA checked).