### PR TITLE
fix: build the is_causal mask on the device of the input

### DIFF
--- a/R/nn-transformer.R
+++ b/R/nn-transformer.R
@@ -106,7 +106,9 @@ nn_transformer_encoder_layer <- nn_module(
         L <- dim(src)[1]
       }
       # Causal mask: True means position should not be attended (mask out future positions)
-      attn_mask_eff <- torch_ones(c(L, L), dtype = torch_bool())
+      # It is created on the device of `src`, as it would otherwise land on the default device and
+      # the attention would fail with a device mismatch once the module is not on the CPU.
+      attn_mask_eff <- torch_ones(c(L, L), dtype = torch_bool(), device = src$device)
       attn_mask_eff <- attn_mask_eff$triu(diagonal = 1) # ones above diagonal
     }
 

--- a/tests/testthat/test-nn-transformer.R
+++ b/tests/testthat/test-nn-transformer.R
@@ -175,3 +175,28 @@ test_that("TransformerEncoderLayer GPU test", {
   expect_equal(dim(output_bf), dim(input_bf))
   }
 })
+
+test_that("TransformerEncoderLayer is_causal works on the GPU", {
+  # is_causal builds the causal mask itself, which has to end up on the device of the input rather
+  # than on the default device
+  skip_if_cuda_not_available()
+  for (batch_first in c(TRUE, FALSE)) {
+    layer <- nn_transformer_encoder_layer(d_model = 8, nhead = 2, dropout = 0,
+                                          batch_first = batch_first)
+    layer$eval()
+    layer$to(device = "cuda")
+    x <- if (batch_first) {
+      torch_randn(3, 5, 8, device = "cuda")  # (batch, seq, feature)
+    } else {
+      torch_randn(5, 3, 8, device = "cuda")  # (seq, batch, feature)
+    }
+
+    out_flag <- layer(x, is_causal = TRUE)
+    expect_equal(dim(out_flag), dim(x))
+
+    # the flag has to agree with passing the same mask explicitly
+    causal_mask <- torch_ones(c(5, 5), dtype = torch_bool(), device = "cuda")$triu(diagonal = 1)
+    out_mask <- layer(x, src_mask = causal_mask)
+    expect_true(as.logical(torch_allclose(out_flag, out_mask)))
+  }
+})


### PR DESCRIPTION
nn_transformer_encoder_layer()$forward() creates the causal mask with torch_ones(), which places it on the default device. Once the module and its input are on the GPU, the attention is then given a CPU mask and fails with a device mismatch, so `is_causal = TRUE` is unusable outside the CPU.

The mask is now created on the device of `src`. On the CPU this is a no-op, as `src$device` is the default device there.

The existing GPU test does not cover `is_causal`, which is how this went unnoticed; a regression test is added for both `batch_first` layouts, checking that the flag agrees with passing the same mask explicitly. It uses skip_if_cuda_not_available() rather than the `if (cuda_is_available())` of the test above it, so that it reports as skipped instead of as an empty test.