### PR TITLE
fix: multihead attention without bias, and one cycle linear annealing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # torch (development version)
 
+- Fixed `nn_multihead_attention()` and `nnf_multi_head_attention_forward()` with `bias = FALSE`
+  when `query` differs from `key` (i.e. cross- and encoder-decoder attention), which failed with
+  `object 'k' not found`. The key and value projections were only computed when a bias was present.
+- Fixed `lr_one_cycle()` with `anneal_strategy = "linear"`, which failed with
+  `attempt to apply non-function` because the annealing function was never assigned.
+
 - Multi-worker dataloaders now use POSIX shared memory for tensor transfer on
   Unix systems, resulting in up to 2x faster data loading. To revert to the
   previous behavior, set `options(torch.dataloader_use_shm = FALSE)`. (#1456)

--- a/R/nnf-activation.R
+++ b/R/nnf-activation.R
@@ -608,10 +608,10 @@ nnf_multi_head_attention_forward <- function(query, # type: Tensor
         w_ <- in_proj_weight[start_:N, ]
         if (!is.null(b_)) {
           b_ <- b_[start_:N]
-          o <- nnf_linear(key, w_, b_)$chunk(2, dim = -1)
-          k <- o[[1]]
-          v <- o[[2]]
         }
+        o <- nnf_linear(key, w_, b_)$chunk(2, dim = -1)
+        k <- o[[1]]
+        v <- o[[2]]
       }
     } else {
 

--- a/R/optim-lr_scheduler.R
+++ b/R/optim-lr_scheduler.R
@@ -455,7 +455,7 @@ lr_one_cycle <- lr_scheduler(
     } else if (anneal_strategy == "cos") {
       self$anneal_func <- self$.annealing_cos
     } else if (anneal_strategy == "linear") {
-      self.anneal_func <- self$.annealing_linear
+      self$anneal_func <- self$.annealing_linear
     }
 
     # Initialize learning rate variables

--- a/tests/testthat/test-nn-activation.R
+++ b/tests/testthat/test-nn-activation.R
@@ -72,6 +72,26 @@ test_that("Multihead attention works", {
   expect_error(nn_multihead_attention(embed_dim = 512, num_heads = 10), regexp="divisible")
 })
 
+test_that("Multihead attention works with bias = FALSE and query != key", {
+  # the encoder-decoder path (key and value identical, query different) used to only compute the
+  # key and value projections when there was a bias, so it failed with `object 'k' not found`.
+  x <- torch_randn(4, 3, 8)
+  q <- x[, 1, drop = FALSE]
+
+  attn <- nn_multihead_attention(embed_dim = 8, num_heads = 2, bias = FALSE, batch_first = TRUE)
+  out <- attn(query = q, key = x, value = x, need_weights = FALSE)
+  expect_equal(dim(out[[1]]), c(4, 1, 8))
+
+  # cross-attention, i.e. all three tensors different, and self-attention still work
+  v <- torch_randn(4, 3, 8)
+  expect_equal(dim(attn(query = q, key = x, value = v, need_weights = FALSE)[[1]]), c(4, 1, 8))
+  expect_equal(dim(attn(query = x, key = x, value = x, need_weights = FALSE)[[1]]), c(4, 3, 8))
+
+  # with a bias the encoder-decoder path is unchanged
+  attn_bias <- nn_multihead_attention(embed_dim = 8, num_heads = 2, bias = TRUE, batch_first = TRUE)
+  expect_equal(dim(attn_bias(query = q, key = x, value = x, need_weights = FALSE)[[1]]), c(4, 1, 8))
+})
+
 test_that("silu works", {
   
   silu <- nn_silu()

--- a/tests/testthat/test-optim-lr_scheduler.R
+++ b/tests/testthat/test-optim-lr_scheduler.R
@@ -46,6 +46,42 @@ test_that("lr_one_cycle", {
   expect_error(scheduler$step())
 })
 
+test_that("lr_one_cycle supports anneal_strategy = 'linear'", {
+  # `anneal_func` was assigned to `self.anneal_func` instead of `self$anneal_func`, so the linear
+  # strategy left it unset and stepping failed with `attempt to apply non-function`.
+  m <- nn_linear(10, 10)
+  o <- optim_adam(params = m$parameters, lr = 1)
+  scheduler <- lr_one_cycle(
+    optimizer = o, max_lr = 0.5, total_steps = 10, anneal_strategy = "linear"
+  )
+
+  lrs <- sapply(1:6, function(i) {
+    scheduler$step()
+    o$param_groups[[1]]$lr
+  })
+
+  # after the warmup peak the decay is linear, i.e. the differences are constant
+  decay <- diff(lrs[2:6])
+  expect_equal(max(abs(decay - mean(decay))), 0, tolerance = 1e-6)
+
+  # and it differs from the cosine strategy
+  o2 <- optim_adam(params = nn_linear(10, 10)$parameters, lr = 1)
+  scheduler2 <- lr_one_cycle(
+    optimizer = o2, max_lr = 0.5, total_steps = 10, anneal_strategy = "cos"
+  )
+  lrs_cos <- sapply(1:6, function(i) {
+    scheduler2$step()
+    o2$param_groups[[1]]$lr
+  })
+  expect_false(isTRUE(all.equal(lrs, lrs_cos)))
+
+  expect_error(
+    lr_one_cycle(optimizer = optim_adam(params = nn_linear(2, 2)$parameters, lr = 1),
+      max_lr = 0.5, total_steps = 10, anneal_strategy = "nope"),
+    regexp = "anneal_strategy"
+  )
+})
+
 test_that("lr_step", {
   m <- nn_linear(10, 10)
   o <- optim_adam(params = m$parameters, lr = 1)


### PR DESCRIPTION
Both bugs were found while auditing mlr3torch, which exposes the affected options as tunable hyperparameters.

* `nnf_multi_head_attention_forward()` failed with `object 'k' not found` when `bias = FALSE` and `query` was not the same tensor as `key`, i.e. for cross-attention and encoder-decoder attention. In the branch that handles a shared key and value, the key/value projection was computed inside the `if (!is.null(b_))` block, so both `k` and `v` were left unassigned when there was no bias. The projection is now computed unconditionally and only the bias slice remains conditional, matching the surrounding branches.

* `lr_one_cycle()` failed with `attempt to apply non-function` when `anneal_strategy = "linear"`, because the annealing function was assigned to `self.anneal_func` rather than `self$anneal_func` and therefore never set. The "cos" branch on the preceding line is spelled correctly.

Both are covered by new regression tests, which fail without the corresponding fix.