### PR TITLE
Fix undefined-variable and typo bugs in distribution constraints and codegen utils

### DIFF
--- a/R/codegen-utils.R
+++ b/R/codegen-utils.R
@@ -9,7 +9,7 @@ as_1_based_dim <- function(x) {
 }
 
 as_1_based_tensor_list <- function(x) {
-  tensors <- lapply(tensors, as_1_based_tensor)
+  tensors <- lapply(x, as_1_based_tensor)
 }
 
 as_1_based_tensor <- function(x) {

--- a/R/distributions-categorical.R
+++ b/R/distributions-categorical.R
@@ -53,7 +53,7 @@ Categorical <- R6::R6Class(
 
       .args$validate_args <- self$.validate_args
 
-      new <- private$.get_checked_instance(self, .instance, .args)
+      new <- private$.get_checked_instance(self, instance, .args)
       new
     },
     sample = function(sample_shape = list()) {

--- a/R/distributions-constraints.R
+++ b/R/distributions-constraints.R
@@ -217,7 +217,7 @@ is_dependent <- function(object) {
   public = list(
     upper_bound = NULL,
     initialize = function(upper_bound) {
-      self$upper_bound <- lower_bound
+      self$upper_bound <- upper_bound
     },
     check = function(value) {
       self$upper_bound < value
@@ -269,7 +269,7 @@ is_dependent <- function(object) {
       self$upper_bound <- upper_bound
     },
     check = function(value) {
-      (self.$ower_bound <= value) & (value < self$upper_bound)
+      (self$lower_bound <= value) & (value < self$upper_bound)
     },
     print = function() {
       cat(glue::glue(

--- a/tests/testthat/test-distributions-constraints.R
+++ b/tests/testthat/test-distributions-constraints.R
@@ -33,3 +33,20 @@ test_that("lower cholesky", {
   x <- torch_eye(2, 2)$unsqueeze(1)$mul(-2)
   expect_equal_to_r(constraint_lower_cholesky$check(x), rep(FALSE, 1))
 })
+
+test_that("less than", {
+  constraint <- constraint_less_than$new(1)
+
+  expect_equal_to_r(constraint$check(torch_tensor(0.5)), TRUE)
+  expect_equal_to_r(constraint$check(torch_tensor(1.5)), FALSE)
+  expect_equal_to_r(constraint$upper_bound, 1)
+})
+
+test_that("half open interval", {
+  constraint <- constraint_half_open_interval$new(0, 1)
+
+  expect_equal_to_r(constraint$check(torch_tensor(0)), TRUE)
+  expect_equal_to_r(constraint$check(torch_tensor(0.5)), TRUE)
+  expect_equal_to_r(constraint$check(torch_tensor(1)), FALSE)
+  expect_equal_to_r(constraint$check(torch_tensor(-1)), FALSE)
+})


### PR DESCRIPTION


- R/distributions-constraints.R: .LessThan$initialize referenced an undefined `lower_bound` instead of the `upper_bound` parameter.
- R/distributions-constraints.R: .HalfOpenInterval$check had a typo `self.$ower_bound` instead of `self$lower_bound`.
- R/distributions-categorical.R: Categorical$expand referenced an undefined `.instance`; use the method's `instance` parameter, matching the sibling expand() implementations.
- R/codegen-utils.R: as_1_based_tensor_list mapped over an undefined `tensors` instead of its `x` parameter.
- Add testthat coverage for .LessThan and .HalfOpenInterval constraints.

Found with [ry](https://github.com/sims1253/ry)