### PR TITLE
fix: interpret ignore_index as a 1-based class index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@
 - On Windows, the install lib directory is now prepended to `PATH` at load so
   cuDNN's lazily-loaded sub-DLLs (e.g. `cudnn_graph64_9.dll`) resolve; cuDNN-backed
   CUDA ops previously failed with "Could not locate cudnn_graph64_9.dll".
+- The `ignore_index` argument of `nnf_cross_entropy()`, `nnf_nll_loss()`,
+  `nn_cross_entropy_loss()` and `nn_nll_loss()` is now interpreted as the 1-based class
+  index that `target` already used. It was forwarded to libtorch unconverted while the
+  target was converted, so it ignored the class to the left of the requested one, and the
+  last class could not be ignored at all. Passing `0` is now an error instead of silently
+  ignoring the first class. The default `-100`, and any other negative sentinel, is
+  unaffected. The documented target range was corrected to \eqn{1 \leq target \leq C}.
 
 # torch 0.17.0
 

--- a/R/nn-loss.R
+++ b/R/nn-loss.R
@@ -139,13 +139,14 @@ nn_l1_loss <- nn_module(
 #'   be applied, `'mean'`: the weighted mean of the output is taken,
 #'   `'sum'`: the output will be summed.
 #' @param ignore_index (int, optional): Specifies a target value that is ignored
-#'   and does not contribute to the input gradient.
+#'   and does not contribute to the input gradient. Like `target`, this is a 1-based
+#'   class index. The default `-100` is never a valid target and therefore ignores nothing.
 #'
 #' @section Shape:
 #' - Input: \eqn{(N, C)} where `C = number of classes`, or
 #'   \eqn{(N, C, d_1, d_2, ..., d_K)} with \eqn{K \geq 1}
 #'   in the case of `K`-dimensional loss.
-#' - Target: \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1}, or
+#' - Target: \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C}, or
 #'   \eqn{(N, d_1, d_2, ..., d_K)} with \eqn{K \geq 1} in the case of
 #'   K-dimensional loss.
 #' - Output: scalar.
@@ -779,8 +780,9 @@ nn_soft_margin_loss <- nn_module(
 #' @param weight (Tensor, optional): a manual rescaling weight given to each class.
 #'   If given, has to be a Tensor of size `C`
 #' @param ignore_index (int, optional): Specifies a target value that is ignored
-#'   and does not contribute to the input gradient. When `size_average` is
-#'   `TRUE`, the loss is averaged over non-ignored targets.
+#'   and does not contribute to the input gradient. Like `target`, this is a 1-based
+#'   class index. The default `-100` is never a valid target and therefore ignores nothing.
+#'   When `size_average` is `TRUE`, the loss is averaged over non-ignored targets.
 #' @param reduction (string, optional): Specifies the reduction to apply to the output:
 #'   `'none'` | `'mean'` | `'sum'`. `'none'`: no reduction will be applied,
 #'   `'mean'`: the sum of the output will be divided by the number of
@@ -790,7 +792,7 @@ nn_soft_margin_loss <- nn_module(
 #' - Input: \eqn{(N, C)} where `C = number of classes`, or
 #' \eqn{(N, C, d_1, d_2, ..., d_K)} with \eqn{K \geq 1}
 #' in the case of `K`-dimensional loss.
-#' - Target: \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1}, or
+#' - Target: \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C}, or
 #' \eqn{(N, d_1, d_2, ..., d_K)} with \eqn{K \geq 1} in the case of
 #' K-dimensional loss.
 #' - Output: scalar.

--- a/R/nnf-loss.R
+++ b/R/nnf-loss.R
@@ -361,12 +361,13 @@ nnf_margin_ranking_loss <- function(input1, input2, target, margin = 0,
 #' @param input \eqn{(N, C)} where `C = number of classes` or \eqn{(N, C, H, W)} in
 #'   case of 2D Loss, or \eqn{(N, C, d_1, d_2, ..., d_K)} where \eqn{K \geq 1} in
 #'   the case of K-dimensional loss.
-#' @param target \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1},
+#' @param target \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C},
 #'   or \eqn{(N, d_1, d_2, ..., d_K)} where \eqn{K \geq 1} for K-dimensional loss.
 #' @param weight (Tensor, optional) a manual rescaling weight given to each class.
 #'   If given, has to be a Tensor of size `C`
 #' @param ignore_index (int, optional) Specifies a target value that is ignored and
-#'   does not contribute to the input gradient.
+#'   does not contribute to the input gradient. Like `target`, this is a 1-based class
+#'   index. The default `-100` is never a valid target and therefore ignores nothing.
 #'
 #' @export
 nnf_nll_loss <- function(input, target, weight = NULL, ignore_index = -100,
@@ -383,12 +384,13 @@ nnf_nll_loss <- function(input, target, weight = NULL, ignore_index = -100,
 #' @param input (Tensor) \eqn{(N, C)} where `C = number of classes` or \eqn{(N, C, H, W)}
 #'   in case of 2D Loss, or \eqn{(N, C, d_1, d_2, ..., d_K)} where \eqn{K \geq 1}
 #'   in the case of K-dimensional loss.
-#' @param target (Tensor) \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1},
+#' @param target (Tensor) \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C},
 #'   or \eqn{(N, d_1, d_2, ..., d_K)} where \eqn{K \geq 1} for K-dimensional loss.
 #' @param weight (Tensor, optional) a manual rescaling weight given to each class. If
 #'   given, has to be a Tensor of size `C`
 #' @param ignore_index (int, optional) Specifies a target value that is ignored
-#'   and does not contribute to the input gradient.
+#'   and does not contribute to the input gradient. Like `target`, this is a 1-based
+#'   class index. The default `-100` is never a valid target and therefore ignores nothing.
 #'
 #' @export
 nnf_cross_entropy <- function(input, target, weight = NULL, ignore_index = -100,

--- a/R/with-indices.R
+++ b/R/with-indices.R
@@ -77,14 +77,29 @@ torch_argmin <- function(self, dim = NULL, keepdim = FALSE) {
   o
 }
 
+# `ignore_index` names a target *value*, and is compared against the target inside libtorch after
+# `to_index_tensor()` has made that target 0 based. It therefore has to undergo the same
+# translation, or it selects the class one to the left of the one that was asked for.
+# Values that cannot be a 1 based class index are left alone: the default `-100`, and any other
+# negative sentinel, is meant to match no target at all and does so in either convention.
+to_index_ignore_index <- function(ignore_index) {
+  if (is.null(ignore_index)) {
+    return(ignore_index)
+  }
+  if (ignore_index == 0) {
+    value_error("`ignore_index` is a 1 based class index, so it cannot be 0. Use a negative value (e.g. the default -100) for a target value that never occurs.")
+  }
+  if (ignore_index >= 1) ignore_index - 1L else ignore_index
+}
+
 torch_nll_loss <- function(self, target, weight = list(), reduction = torch_reduction_mean(), ignore_index = -100) {
   target <- to_index_tensor(target)
-  .torch_nll_loss(self, target, weight, reduction, ignore_index)
+  .torch_nll_loss(self, target, weight, reduction, to_index_ignore_index(ignore_index))
 }
 
 torch_nll_loss2d <- function(self, target, weight = list(), reduction = torch_reduction_mean(), ignore_index = -100) {
   target <- to_index_tensor(target)
-  .torch_nll_loss2d(self, target, weight, reduction, ignore_index)
+  .torch_nll_loss2d(self, target, weight, reduction, to_index_ignore_index(ignore_index))
 }
 
 #' @rdname torch_argsort
@@ -98,7 +113,7 @@ torch_cross_entropy_loss <- function(self, target, weight = list(),
   target <- to_index_tensor(target)
   .torch_cross_entropy_loss(
     self = self, target = target, weight = weight,
-    reduction = reduction, ignore_index = ignore_index
+    reduction = reduction, ignore_index = to_index_ignore_index(ignore_index)
   )
 }
 
@@ -106,9 +121,9 @@ torch_nll_loss_nd <- function(self, target, weight = list(), reduction = torch_r
                                ignore_index = -100L) {
   target <- to_index_tensor(target)
   .torch_nll_loss_nd(
-    self = self, target = target, weight = weight, 
-    reduction = reduction, 
-    ignore_index = ignore_index
+    self = self, target = target, weight = weight,
+    reduction = reduction,
+    ignore_index = to_index_ignore_index(ignore_index)
   )
 }
 

--- a/man/nn_cross_entropy_loss.Rd
+++ b/man/nn_cross_entropy_loss.Rd
@@ -11,7 +11,7 @@ nn_cross_entropy_loss(weight = NULL, ignore_index = -100, reduction = "mean")
 If given, has to be a Tensor of size \code{C}}
 
 \item{ignore_index}{(int, optional): Specifies a target value that is ignored
-and does not contribute to the input gradient. When \code{size_average} is
+and does not contribute to the input gradient. Like \code{target}, this is a 1-based class index. The default \code{-100} is never a valid target and therefore ignores nothing. When \code{size_average} is
 \code{TRUE}, the loss is averaged over non-ignored targets.}
 
 \item{reduction}{(string, optional): Specifies the reduction to apply to the output:
@@ -60,7 +60,7 @@ where \eqn{K} is the number of dimensions, and a target of appropriate shape
 \item Input: \eqn{(N, C)} where \verb{C = number of classes}, or
 \eqn{(N, C, d_1, d_2, ..., d_K)} with \eqn{K \geq 1}
 in the case of \code{K}-dimensional loss.
-\item Target: \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1}, or
+\item Target: \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C}, or
 \eqn{(N, d_1, d_2, ..., d_K)} with \eqn{K \geq 1} in the case of
 K-dimensional loss.
 \item Output: scalar.

--- a/man/nn_nll_loss.Rd
+++ b/man/nn_nll_loss.Rd
@@ -12,7 +12,7 @@ class. If given, it has to be a Tensor of size \code{C}. Otherwise, it is
 treated as if having all ones.}
 
 \item{ignore_index}{(int, optional): Specifies a target value that is ignored
-and does not contribute to the input gradient.}
+and does not contribute to the input gradient. Like code{target}, this is a 1-based class index. The default code{-100} is never a valid target and therefore ignores nothing.}
 
 \item{reduction}{(string, optional): Specifies the reduction to apply to the output:
 \code{'none'} | \code{'mean'} | \code{'sum'}. \code{'none'}: no reduction will
@@ -75,7 +75,7 @@ where \eqn{K} is the number of dimensions, and a target of appropriate shape
 \item Input: \eqn{(N, C)} where \verb{C = number of classes}, or
 \eqn{(N, C, d_1, d_2, ..., d_K)} with \eqn{K \geq 1}
 in the case of \code{K}-dimensional loss.
-\item Target: \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1}, or
+\item Target: \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C}, or
 \eqn{(N, d_1, d_2, ..., d_K)} with \eqn{K \geq 1} in the case of
 K-dimensional loss.
 \item Output: scalar.

--- a/man/nnf_cross_entropy.Rd
+++ b/man/nnf_cross_entropy.Rd
@@ -17,14 +17,14 @@ nnf_cross_entropy(
 in case of 2D Loss, or \eqn{(N, C, d_1, d_2, ..., d_K)} where \eqn{K \geq 1}
 in the case of K-dimensional loss.}
 
-\item{target}{(Tensor) \eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1},
+\item{target}{(Tensor) \eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C},
 or \eqn{(N, d_1, d_2, ..., d_K)} where \eqn{K \geq 1} for K-dimensional loss.}
 
 \item{weight}{(Tensor, optional) a manual rescaling weight given to each class. If
 given, has to be a Tensor of size \code{C}}
 
 \item{ignore_index}{(int, optional) Specifies a target value that is ignored
-and does not contribute to the input gradient.}
+and does not contribute to the input gradient. Like code{target}, this is a 1-based class index. The default code{-100} is never a valid target and therefore ignores nothing.}
 
 \item{reduction}{(string, optional) – Specifies the reduction to apply to the
 output: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean':

--- a/man/nnf_nll_loss.Rd
+++ b/man/nnf_nll_loss.Rd
@@ -17,14 +17,14 @@ nnf_nll_loss(
 case of 2D Loss, or \eqn{(N, C, d_1, d_2, ..., d_K)} where \eqn{K \geq 1} in
 the case of K-dimensional loss.}
 
-\item{target}{\eqn{(N)} where each value is \eqn{0 \leq \mbox{targets}[i] \leq C-1},
+\item{target}{\eqn{(N)} where each value is \eqn{1 \leq \mbox{targets}[i] \leq C},
 or \eqn{(N, d_1, d_2, ..., d_K)} where \eqn{K \geq 1} for K-dimensional loss.}
 
 \item{weight}{(Tensor, optional) a manual rescaling weight given to each class.
 If given, has to be a Tensor of size \code{C}}
 
 \item{ignore_index}{(int, optional) Specifies a target value that is ignored and
-does not contribute to the input gradient.}
+does not contribute to the input gradient. Like code{target}, this is a 1-based class index. The default code{-100} is never a valid target and therefore ignores nothing.}
 
 \item{reduction}{(string, optional) – Specifies the reduction to apply to the
 output: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean':

--- a/tests/testthat/test-with-indices.R
+++ b/tests/testthat/test-with-indices.R
@@ -90,3 +90,43 @@ test_that("bincount is 1 indexed", {
   
   
 })
+test_that("ignore_index is 1 indexed", {
+  # `ignore_index` names a target value, and targets are 1 based in this package. It used to be
+  # forwarded to libtorch unchanged while the target was converted, so it selected the class to the
+  # left of the requested one, and the last class could not be ignored at all.
+  logits <- torch_tensor(matrix(c(10, 0, 0, 0, 10, 0, 0, 0, 10), nrow = 3, byrow = TRUE))
+  loss_for <- function(cls, ...) {
+    target <- torch_tensor(rep(cls, 3L), dtype = torch_long())
+    as.numeric(nnf_cross_entropy(logits, target, ...))
+  }
+
+  for (cls in 1:3) {
+    # ignoring exactly the class that occurs leaves nothing to average over
+    expect_true(is.nan(loss_for(cls, ignore_index = cls)))
+    # while ignoring any other class leaves the loss untouched
+    for (other in setdiff(1:3, cls)) {
+      expect_equal(loss_for(cls, ignore_index = other), loss_for(cls), tolerance = 1e-6)
+    }
+  }
+
+  # the default sentinel is not a valid target and must ignore nothing
+  expect_false(is.nan(loss_for(1)))
+  expect_equal(loss_for(1, ignore_index = -100), loss_for(1), tolerance = 1e-6)
+
+  # 0 is not a valid 1 based class index
+  expect_error(loss_for(1, ignore_index = 0), regexp = "1 based class index")
+
+  # nnf_nll_loss goes through the same conversion
+  log_probs <- nnf_log_softmax(logits, dim = 2)
+  nll_for <- function(cls, ...) {
+    target <- torch_tensor(rep(cls, 3L), dtype = torch_long())
+    as.numeric(nnf_nll_loss(log_probs, target, ...))
+  }
+  expect_true(is.nan(nll_for(3, ignore_index = 3)))
+  expect_equal(nll_for(3, ignore_index = 1), nll_for(3), tolerance = 1e-6)
+
+  # and so does the nn_module interface
+  expect_true(is.nan(as.numeric(
+    nn_cross_entropy_loss(ignore_index = 2)(logits, torch_tensor(rep(2L, 3L), dtype = torch_long()))
+  )))
+})


### PR DESCRIPTION
`with-indices.R` exists to translate R's 1-based indexing into libtorch's 0-based one. It converted the `target` of the NLL and cross entropy losses but forwarded `ignore_index` unchanged, even though `ignore_index` names a target value and is compared against the already-converted target inside libtorch.

As a result `ignore_index = k` ignored class `k - 1`, and the last class could not be ignored at all. Nothing caught this because the default `-100` is a sentinel that matches no target in either convention, and there was no test for the argument.

`to_index_ignore_index()` now applies the same shift to any value that can be a 1-based class index, and leaves negative sentinels alone. `0` becomes an error rather than silently ignoring the first class.

The documented target range was `0 <= target <= C-1`, copied from PyTorch, which `to_index_tensor()` has always rejected; it now reads `1 <= target <= C`.

man/ was updated by hand because roxygen2 has to load the package to run.